### PR TITLE
TossUP/CanToss

### DIFF
--- a/build.gradle.orig
+++ b/build.gradle.orig
@@ -1,7 +1,8 @@
 import groovyx.gpars.GParsPool
 import groovy.xml.NamespaceBuilder
-//import org.kohsuke.github.GitHub
-//import org.ajoberstar.grgit.Credentials
+import org.kohsuke.github.GitHub
+import org.ajoberstar.grgit.Grgit 
+import org.ajoberstar.grgit.Credentials
 
 buildscript {
     repositories {
@@ -17,7 +18,7 @@ buildscript {
 }
 
 plugins {
-    //id 'org.ajoberstar.grgit' version '1.3.2'
+    id 'org.ajoberstar.grgit' version '1.3.2'
 }
 
 apply plugin: 'java'
@@ -38,7 +39,7 @@ def version = extProp["version"]
 
 def username = ''                                           // Username for GitHub (will request JIT via console input)
 def password = ''                                           // Password for GitHub (will request JIT via console input)
-//def grgit = null
+def grgit = null
 
 def dist = 'build/dist/'
 def archivePath = dist + 'ShootOFF.jar'
@@ -305,8 +306,8 @@ task pushZipRelease(dependsOn: zipRelease) {
 
         // Update version metadata
 
-        //grgit = Grgit.open('.', new Credentials(username: username, password: password))
-        //grgit.checkout(branch: 'gh-pages', createBranch: false)
+        grgit = Grgit.open('.', new Credentials(username: username, password: password))
+        grgit.checkout(branch: 'gh-pages', createBranch: false)
 
         def versionMetadata = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
             '<stableRelease version=\"' + version + '\" ' +
@@ -316,11 +317,11 @@ task pushZipRelease(dependsOn: zipRelease) {
         def versionFile = new File('shootoff-version.xml')
         versionFile.write(versionMetadata, 'UTF-8')
 
-        //grgit.commit(message: 'Update version file to ' + version, all: true)
-        //grgit.push()
+        grgit.commit(message: 'Update version file to ' + version, all: true)
+        grgit.push()
 
-        //grgit.checkout(branch: 'master', createBranch: false)
-        //grgit.close()
+        grgit.checkout(branch: 'master', createBranch: false)
+        grgit.close()
     }
 }
 
@@ -517,14 +518,14 @@ task pushFxRelease(dependsOn: fxRelease) {
             password = new String(password)
         }
 
-        //grgit = Grgit.open('.', new Credentials(username: username, password: password))
-        //grgit.checkout(branch: 'gh-pages', createBranch: false)
+        grgit = Grgit.open('.', new Credentials(username: username, password: password))
+        grgit.checkout(branch: 'gh-pages', createBranch: false)
 
         delete jwsDir + 'libs'
         copyJWSLibs.execute()
         copyJWSConfig.execute()
 
-        //grgit.add(patterns: [jwsDir + 'libs'])
+        grgit.add(patterns: [jwsDir + 'libs'])
 
         def resourcesArchive = new File(jwsDir + writableResources)
 
@@ -535,11 +536,11 @@ task pushFxRelease(dependsOn: fxRelease) {
         def resourcesFile = new File(jwsDir + writableResourcesMetadata)
         resourcesFile.write(resourcesMetadata, 'UTF-8')
 
-        //grgit.commit(message: 'Update JWS to ' + version, all: true)
-        //grgit.push()
+        grgit.commit(message: 'Update JWS to ' + version, all: true)
+        grgit.push()
 
-        //grgit.checkout(branch: 'master', createBranch: false)
-        //grgit.close()
+        grgit.checkout(branch: 'master', createBranch: false)
+        grgit.close()
     }
 }
 

--- a/log/server.log
+++ b/log/server.log
@@ -1,0 +1,5583 @@
+2016-02-19 12:49:06,683 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 12:49:06,687 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 12:49:06,688 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 12:49:06,688 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 12:49:06,781 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 12:49:06,785 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 12:49:06,786 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 12:49:06,787 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 12:49:06,787 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 12:49:06,788 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 12:49:06,788 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 12:49:06,789 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 12:49:06,789 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 12:49:06,792 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 12:49:06,793 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 12:49:06,794 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 12:49:06,794 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 12:49:06,795 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 12:49:06,796 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 12:49:06,796 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 12:49:06,797 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 12:49:06,799 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 12:49:06,800 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 12:49:06,803 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 12:49:06,804 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 12:49:06,876 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 12:49:06,876 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 12:49:06,939 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 12:49:06,940 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 12:49:06,941 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 12:49:06,944 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 12:49:06,949 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 12:49:06,950 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 12:49:06,954 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 12:49:06,956 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 12:49:06,956 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 12:49:06,979 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 12:49:07,094 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 12:49:07,308 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 12:49:07,324 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 12:49:07,324 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 12:49:07,324 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 12:49:07,325 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 12:49:07,360 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 12:49:07,364 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 12:49:07,364 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 12:49:07,372 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 12:49:07,372 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 12:49:07,379 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 12:49:07,391 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 12:49:07,397 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 12:49:07,398 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 12:49:07,400 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 12:49:07,402 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 12:49:07,403 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 12:49:07,405 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 12:49:07,406 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 12:49:07,407 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 12:49:07,408 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 12:49:07,408 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 12:49:07,409 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 12:49:07,410 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 12:49:07,410 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 12:49:07,411 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 12:49:07,411 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 12:49:07,412 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 12:49:07,413 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 12:49:07,414 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 12:49:07,415 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 12:49:07,417 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 12:49:07,418 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 12:49:07,419 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 12:49:07,420 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 12:49:07,421 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 12:49:07,422 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 12:49:07,422 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 12:49:07,424 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 12:49:07,424 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 12:49:07,425 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 12:49:07,426 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 12:49:07,427 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 12:49:07,428 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 12:49:07,428 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 12:49:07,429 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 12:49:07,431 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 12:49:07,432 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 12:49:07,432 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 12:49:07,433 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 12:49:07,434 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 12:49:07,435 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 12:49:07,444 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 12:49:07,445 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 12:49:07,445 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 12:49:07,446 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 12:49:07,447 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 12:49:07,447 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 12:49:07,728 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 12:49:07,728 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 12:49:07,728 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 12:49:07,831 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 12:49:07,831 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 12:49:07,831 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 12:49:07,920 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 12:49:07,920 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 12:49:07,920 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 12:49:07,983 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 12:49:07,983 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 12:49:07,983 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 12:49:07,983 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 12:49:08,028 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 12:49:08,028 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 12:49:08,028 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 12:49:08,028 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 12:49:08,029 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 12:49:08,036 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 12:49:08,036 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 12:49:08,036 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 12:49:08,036 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 12:49:08,036 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 12:49:08,037 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 12:49:08,037 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 12:49:08,037 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 12:49:08,037 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 12:49:08,037 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 12:49:08,038 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 12:49:08,038 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 12:49:08,038 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 12:49:08,038 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 12:49:08,038 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 12:49:08,038 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 12:49:08,038 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 12:49:08,038 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 12:49:08,038 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 12:49:08,039 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 12:49:08,039 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 12:49:08,039 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 12:49:08,039 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 12:49:08,039 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 12:49:08,082 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 12:49:08,082 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 12:49:08,082 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 12:49:08,098 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 12:49:08,098 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 12:49:08,098 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 12:49:08,098 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 12:49:08,098 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 12:49:08,098 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 12:49:08,098 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 12:49:08,099 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 12:49:08,105 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 12:49:08,105 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 12:49:08,106 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 12:49:08,107 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 12:49:08,107 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 12:49:08,109 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 12:49:08,110 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 12:49:08,110 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 12:49:08,111 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 12:49:08,111 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 12:49:08,111 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 12:49:08,111 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 12:49:08,111 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 12:49:08,111 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 12:49:08,111 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 12:49:08,111 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 12:49:09,425 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 12:49:09,426 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 12:49:09,427 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 12:51:30,538 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 12:51:30,539 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 12:51:30,541 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 12:51:30,542 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 12:51:30,542 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 12:51:30,542 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 12:51:30,542 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 12:51:30,542 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 12:51:30,550 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 12:51:49,485 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 12:51:49,488 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 12:51:49,488 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 12:51:49,489 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 12:51:49,588 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 12:51:49,592 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 12:51:49,593 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 12:51:49,594 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 12:51:49,594 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 12:51:49,595 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 12:51:49,595 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 12:51:49,596 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 12:51:49,596 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 12:51:49,599 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 12:51:49,600 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 12:51:49,601 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 12:51:49,601 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 12:51:49,602 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 12:51:49,603 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 12:51:49,603 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 12:51:49,605 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 12:51:49,606 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 12:51:49,607 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 12:51:49,612 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 12:51:49,613 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 12:51:49,682 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 12:51:49,682 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 12:51:49,739 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 12:51:49,742 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 12:51:49,743 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 12:51:49,746 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 12:51:49,752 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 12:51:49,753 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 12:51:49,759 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 12:51:49,760 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 12:51:49,760 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 12:51:49,783 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 12:51:49,902 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 12:51:50,114 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 12:51:50,130 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 12:51:50,130 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 12:51:50,130 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 12:51:50,131 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 12:51:50,166 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 12:51:50,169 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 12:51:50,169 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 12:51:50,178 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 12:51:50,178 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 12:51:50,186 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 12:51:50,201 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 12:51:50,208 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 12:51:50,209 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 12:51:50,211 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 12:51:50,214 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 12:51:50,216 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 12:51:50,218 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 12:51:50,219 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 12:51:50,221 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 12:51:50,222 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 12:51:50,223 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 12:51:50,223 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 12:51:50,224 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 12:51:50,225 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 12:51:50,226 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 12:51:50,227 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 12:51:50,228 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 12:51:50,230 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 12:51:50,231 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 12:51:50,232 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 12:51:50,233 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 12:51:50,234 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 12:51:50,236 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 12:51:50,237 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 12:51:50,238 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 12:51:50,239 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 12:51:50,240 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 12:51:50,241 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 12:51:50,242 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 12:51:50,243 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 12:51:50,244 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 12:51:50,245 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 12:51:50,246 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 12:51:50,246 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 12:51:50,246 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 12:51:50,248 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 12:51:50,249 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 12:51:50,250 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 12:51:50,250 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 12:51:50,250 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 12:51:50,251 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 12:51:50,258 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 12:51:50,259 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 12:51:50,259 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 12:51:50,260 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 12:51:50,260 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 12:51:50,261 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 12:51:50,566 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 12:51:50,566 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 12:51:50,566 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 12:51:50,663 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 12:51:50,663 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 12:51:50,663 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 12:51:50,748 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 12:51:50,748 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 12:51:50,749 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 12:51:50,812 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 12:51:50,813 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 12:51:50,813 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 12:51:50,813 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 12:51:50,859 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 12:51:50,859 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 12:51:50,859 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 12:51:50,859 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 12:51:50,860 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 12:51:50,867 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 12:51:50,867 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 12:51:50,868 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 12:51:50,868 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 12:51:50,868 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 12:51:50,868 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 12:51:50,868 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 12:51:50,868 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 12:51:50,868 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 12:51:50,869 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 12:51:50,869 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 12:51:50,869 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 12:51:50,869 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 12:51:50,869 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 12:51:50,869 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 12:51:50,869 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 12:51:50,870 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 12:51:50,870 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 12:51:50,870 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 12:51:50,870 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 12:51:50,870 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 12:51:50,870 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 12:51:50,870 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 12:51:50,871 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 12:51:50,892 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 12:51:50,893 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 12:51:50,893 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 12:51:50,910 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 12:51:50,911 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 12:51:50,911 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 12:51:50,911 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 12:51:50,911 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 12:51:50,911 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 12:51:50,911 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 12:51:50,911 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 12:51:50,919 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 12:51:50,919 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 12:51:50,919 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 12:51:50,920 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 12:51:50,920 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 12:51:50,923 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 12:51:50,924 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 12:51:50,924 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 12:51:50,925 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 12:51:50,925 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 12:51:50,925 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 12:51:50,925 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 12:51:50,925 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 12:51:50,925 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 12:51:50,926 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 12:51:50,926 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 12:51:52,128 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 12:51:52,128 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 12:51:52,129 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 12:52:13,427 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 12:52:13,427 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 12:52:13,427 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 12:52:13,427 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 12:52:13,427 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 12:52:13,428 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 12:52:13,430 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 12:52:32,511 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 12:52:32,515 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 12:52:32,515 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 12:52:32,515 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 12:52:32,605 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 12:52:32,609 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 12:52:32,610 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 12:52:32,610 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 12:52:32,611 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 12:52:32,612 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 12:52:32,612 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 12:52:32,613 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 12:52:32,613 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 12:52:32,616 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 12:52:32,617 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 12:52:32,618 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 12:52:32,618 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 12:52:32,619 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 12:52:32,620 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 12:52:32,620 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 12:52:32,622 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 12:52:32,623 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 12:52:32,624 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 12:52:32,628 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 12:52:32,629 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 12:52:32,706 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 12:52:32,706 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 12:52:32,773 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 12:52:32,774 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 12:52:32,775 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 12:52:32,778 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 12:52:32,783 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 12:52:32,784 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 12:52:32,790 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 12:52:32,792 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 12:52:32,792 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 12:52:32,824 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 12:52:32,925 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 12:52:33,143 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 12:52:33,158 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 12:52:33,158 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 12:52:33,158 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 12:52:33,159 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 12:52:33,193 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 12:52:33,196 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 12:52:33,197 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 12:52:33,205 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 12:52:33,205 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 12:52:33,213 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 12:52:33,228 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 12:52:33,234 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 12:52:33,235 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 12:52:33,237 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 12:52:33,239 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 12:52:33,241 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 12:52:33,242 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 12:52:33,243 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 12:52:33,245 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 12:52:33,246 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 12:52:33,247 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 12:52:33,247 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 12:52:33,248 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 12:52:33,249 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 12:52:33,250 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 12:52:33,251 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 12:52:33,252 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 12:52:33,253 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 12:52:33,254 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 12:52:33,255 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 12:52:33,257 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 12:52:33,258 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 12:52:33,259 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 12:52:33,260 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 12:52:33,261 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 12:52:33,262 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 12:52:33,263 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 12:52:33,264 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 12:52:33,265 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 12:52:33,266 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 12:52:33,267 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 12:52:33,268 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 12:52:33,269 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 12:52:33,270 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 12:52:33,270 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 12:52:33,271 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 12:52:33,272 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 12:52:33,273 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 12:52:33,273 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 12:52:33,274 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 12:52:33,274 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 12:52:33,283 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 12:52:33,285 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 12:52:33,285 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 12:52:33,288 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 12:52:33,288 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 12:52:33,289 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 12:52:33,544 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 12:52:33,544 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 12:52:33,545 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 12:52:33,652 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 12:52:33,652 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 12:52:33,653 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 12:52:33,739 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 12:52:33,739 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 12:52:33,739 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 12:52:33,804 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 12:52:33,804 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 12:52:33,804 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 12:52:33,804 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 12:52:33,853 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 12:52:33,853 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 12:52:33,854 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 12:52:33,854 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 12:52:33,854 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 12:52:33,861 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 12:52:33,861 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 12:52:33,862 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 12:52:33,862 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 12:52:33,862 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 12:52:33,862 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 12:52:33,862 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 12:52:33,863 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 12:52:33,863 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 12:52:33,863 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 12:52:33,863 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 12:52:33,863 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 12:52:33,863 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 12:52:33,864 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 12:52:33,864 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 12:52:33,864 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 12:52:33,864 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 12:52:33,864 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 12:52:33,864 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 12:52:33,864 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 12:52:33,865 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 12:52:33,865 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 12:52:33,865 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 12:52:33,865 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 12:52:33,888 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 12:52:33,888 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 12:52:33,888 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 12:52:33,902 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 12:52:33,903 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 12:52:33,903 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 12:52:33,903 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 12:52:33,903 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 12:52:33,903 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 12:52:33,903 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 12:52:33,903 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 12:52:33,911 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 12:52:33,911 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 12:52:33,911 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 12:52:33,912 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 12:52:33,913 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 12:52:33,925 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 12:52:33,926 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 12:52:33,926 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 12:52:33,927 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 12:52:33,927 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 12:52:33,927 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 12:52:33,927 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 12:52:33,927 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 12:52:33,927 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 12:52:33,927 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 12:52:33,927 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 12:52:35,183 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 12:52:35,183 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 12:52:35,184 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 12:56:55,506 [ShotDetector] INFO  marytts.R 1 New request (input type "TEXT", output type "AUDIO", voice "cmu-slt-hsmm", audio "WAVE")
+2016-02-19 12:56:55,506 [ShotDetector] INFO  marytts.R 1 Handling request using the following modules:
+2016-02-19 12:56:55,506 [ShotDetector] INFO  marytts.R 1 - TextToMaryXML (marytts.modules.TextToMaryXML)
+2016-02-19 12:56:55,506 [ShotDetector] INFO  marytts.R 1 Next module: TextToMaryXML
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 Handling request using the following modules:
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 - JTokeniser (marytts.language.en.JTokeniser)
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 - XML2Utt TokensEn (marytts.language.en.XML2UttTokensEn)
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 - TokenToWords (marytts.language.en.FreeTTSTokenToWords)
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 - Utt2XML WordsEn (marytts.language.en.Utt2XMLWordsEn)
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 - OpenNLPPosTagger (marytts.modules.OpenNLPPosTagger)
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 - JPhonemiser (marytts.modules.JPhonemiser)
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 - Prosody (marytts.language.en.Prosody)
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 - PronunciationModel (marytts.language.en.PronunciationModel)
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 - AcousticModeller (marytts.modules.AcousticModeller)
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 - Synthesis (marytts.modules.Synthesis)
+2016-02-19 12:56:55,508 [ShotDetector] INFO  marytts.R 1 Next module: JTokeniser
+2016-02-19 12:56:55,524 [ShotDetector] INFO  marytts.R 1 Next module: XML2Utt TokensEn
+2016-02-19 12:56:55,537 [ShotDetector] INFO  marytts.R 1 Next module: TokenToWords
+2016-02-19 12:56:55,546 [ShotDetector] INFO  marytts.R 1 Next module: Utt2XML WordsEn
+2016-02-19 12:56:55,556 [ShotDetector] INFO  marytts.R 1 Next module: OpenNLPPosTagger
+2016-02-19 12:56:55,568 [ShotDetector] INFO  marytts.R 1 Next module: JPhonemiser
+2016-02-19 12:56:55,576 [ShotDetector] INFO  marytts.R 1 Next module: Prosody
+2016-02-19 12:56:55,598 [ShotDetector] INFO  marytts.R 1 Next module: PronunciationModel
+2016-02-19 12:56:55,604 [ShotDetector] INFO  marytts.R 1 Next module: AcousticModeller
+2016-02-19 12:56:55,734 [ShotDetector] INFO  marytts.ParameterGeneration Parameter generation for LF0: 
+2016-02-19 12:56:55,734 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 1234
+2016-02-19 12:56:55,741 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=14
+2016-02-19 12:56:55,800 [ShotDetector] INFO  marytts.R 1 Next module: Synthesis
+2016-02-19 12:56:55,834 [ShotDetector] INFO  marytts.HMMSynthesizer Synthesizing one sentence.
+2016-02-19 12:56:55,835 [ShotDetector] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 12:56:55,842 [ShotDetector] INFO  marytts.HTSEngine Number of models in sentence numModel=99  Total number of states numState=495
+2016-02-19 12:56:55,842 [ShotDetector] INFO  marytts.HTSEngine Total number of frames=1568  Number of voiced frames=1094
+2016-02-19 12:56:55,851 [ShotDetector] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 12:56:55,851 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 1562
+2016-02-19 12:56:55,876 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=63
+2016-02-19 12:56:55,881 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=1
+2016-02-19 12:56:55,893 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=24
+2016-02-19 12:56:55,903 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=22
+2016-02-19 12:56:55,907 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=3
+2016-02-19 12:56:55,920 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=23
+2016-02-19 12:56:55,924 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=6
+2016-02-19 12:56:55,933 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=21
+2016-02-19 12:56:55,945 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=20
+2016-02-19 12:56:55,957 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=20
+2016-02-19 12:56:55,964 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=17
+2016-02-19 12:56:55,975 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=19
+2016-02-19 12:56:55,987 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=17
+2016-02-19 12:56:56,000 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=25
+2016-02-19 12:56:56,014 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=25
+2016-02-19 12:56:56,027 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=23
+2016-02-19 12:56:56,036 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=19
+2016-02-19 12:56:56,051 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=19
+2016-02-19 12:56:56,061 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=15
+2016-02-19 12:56:56,072 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=21
+2016-02-19 12:56:56,090 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=15
+2016-02-19 12:56:56,100 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=16
+2016-02-19 12:56:56,111 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=20
+2016-02-19 12:56:56,122 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=15
+2016-02-19 12:56:56,131 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=10
+2016-02-19 12:56:56,147 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=13
+2016-02-19 12:56:56,156 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=11
+2016-02-19 12:56:56,164 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=12
+2016-02-19 12:56:56,174 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=25
+2016-02-19 12:56:56,180 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=15
+2016-02-19 12:56:56,186 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=12
+2016-02-19 12:56:56,194 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 12:56:56,197 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=4
+2016-02-19 12:56:56,203 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 12:56:56,212 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=23
+2016-02-19 12:56:56,212 [ShotDetector] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 12:56:56,220 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 1562
+2016-02-19 12:56:56,232 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=11
+2016-02-19 12:56:56,234 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 12:56:56,243 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=29
+2016-02-19 12:56:56,247 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=5
+2016-02-19 12:56:56,258 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=23
+2016-02-19 12:56:56,270 [ShotDetector] INFO  marytts.HMMSynthesizer Synthesizing one sentence.
+2016-02-19 12:56:56,272 [ShotDetector] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 12:56:56,274 [ShotDetector] INFO  marytts.HTSEngine Number of models in sentence numModel=17  Total number of states numState=85
+2016-02-19 12:56:56,274 [ShotDetector] INFO  marytts.HTSEngine Total number of frames=248  Number of voiced frames=141
+2016-02-19 12:56:56,277 [ShotDetector] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 12:56:56,277 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 242
+2016-02-19 12:56:56,283 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=64
+2016-02-19 12:56:56,286 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=38
+2016-02-19 12:56:56,287 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 12:56:56,288 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=21
+2016-02-19 12:56:56,289 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=2
+2016-02-19 12:56:56,290 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=7
+2016-02-19 12:56:56,292 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=19
+2016-02-19 12:56:56,296 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=21
+2016-02-19 12:56:56,298 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=20
+2016-02-19 12:56:56,300 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 12:56:56,301 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 12:56:56,304 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=26
+2016-02-19 12:56:56,306 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=26
+2016-02-19 12:56:56,308 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=32
+2016-02-19 12:56:56,309 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=15
+2016-02-19 12:56:56,310 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=13
+2016-02-19 12:56:56,310 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 12:56:56,311 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=20
+2016-02-19 12:56:56,311 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=20
+2016-02-19 12:56:56,312 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=15
+2016-02-19 12:56:56,312 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=11
+2016-02-19 12:56:56,313 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=16
+2016-02-19 12:56:56,314 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 12:56:56,315 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=12
+2016-02-19 12:56:56,316 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=7
+2016-02-19 12:56:56,317 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=13
+2016-02-19 12:56:56,317 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=14
+2016-02-19 12:56:56,318 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=14
+2016-02-19 12:56:56,319 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=15
+2016-02-19 12:56:56,320 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=11
+2016-02-19 12:56:56,321 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=9
+2016-02-19 12:56:56,322 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=9
+2016-02-19 12:56:56,322 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 12:56:56,323 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=15
+2016-02-19 12:56:56,324 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=23
+2016-02-19 12:56:56,324 [ShotDetector] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 12:56:56,325 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 242
+2016-02-19 12:56:56,326 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=4
+2016-02-19 12:56:56,327 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=7
+2016-02-19 12:56:56,328 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=20
+2016-02-19 12:56:56,329 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=7
+2016-02-19 12:56:56,329 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=3
+2016-02-19 12:56:56,330 [ShotDetector] INFO  marytts.R 1 Request processed in 824 ms.
+2016-02-19 12:56:56,330 [ShotDetector] INFO  marytts.R 1    TextToMaryXML took 0 ms
+2016-02-19 12:56:56,330 [ShotDetector] INFO  marytts.R 1    JTokeniser took 16 ms
+2016-02-19 12:56:56,330 [ShotDetector] INFO  marytts.R 1    XML2Utt TokensEn took 13 ms
+2016-02-19 12:56:56,330 [ShotDetector] INFO  marytts.R 1    TokenToWords took 9 ms
+2016-02-19 12:56:56,330 [ShotDetector] INFO  marytts.R 1    Utt2XML WordsEn took 10 ms
+2016-02-19 12:56:56,330 [ShotDetector] INFO  marytts.R 1    OpenNLPPosTagger took 12 ms
+2016-02-19 12:56:56,330 [ShotDetector] INFO  marytts.R 1    JPhonemiser took 8 ms
+2016-02-19 12:56:56,331 [ShotDetector] INFO  marytts.R 1    Prosody took 22 ms
+2016-02-19 12:56:56,331 [ShotDetector] INFO  marytts.R 1    PronunciationModel took 6 ms
+2016-02-19 12:56:56,331 [ShotDetector] INFO  marytts.R 1    AcousticModeller took 196 ms
+2016-02-19 12:56:56,331 [ShotDetector] INFO  marytts.R 1    Synthesis took 530 ms
+2016-02-19 12:57:07,492 [ShotDetector] INFO  marytts.R 1 New request (input type "TEXT", output type "AUDIO", voice "cmu-slt-hsmm", audio "WAVE")
+2016-02-19 12:57:07,492 [ShotDetector] INFO  marytts.R 1 Handling request using the following modules:
+2016-02-19 12:57:07,493 [ShotDetector] INFO  marytts.R 1 - TextToMaryXML (marytts.modules.TextToMaryXML)
+2016-02-19 12:57:07,495 [ShotDetector] INFO  marytts.R 1 Next module: TextToMaryXML
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 Handling request using the following modules:
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 - JTokeniser (marytts.language.en.JTokeniser)
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 - XML2Utt TokensEn (marytts.language.en.XML2UttTokensEn)
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 - TokenToWords (marytts.language.en.FreeTTSTokenToWords)
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 - Utt2XML WordsEn (marytts.language.en.Utt2XMLWordsEn)
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 - OpenNLPPosTagger (marytts.modules.OpenNLPPosTagger)
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 - JPhonemiser (marytts.modules.JPhonemiser)
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 - Prosody (marytts.language.en.Prosody)
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 - PronunciationModel (marytts.language.en.PronunciationModel)
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 - AcousticModeller (marytts.modules.AcousticModeller)
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 - Synthesis (marytts.modules.Synthesis)
+2016-02-19 12:57:07,502 [ShotDetector] INFO  marytts.R 1 Next module: JTokeniser
+2016-02-19 12:57:07,503 [ShotDetector] INFO  marytts.R 1 Next module: XML2Utt TokensEn
+2016-02-19 12:57:07,504 [ShotDetector] INFO  marytts.R 1 Next module: TokenToWords
+2016-02-19 12:57:07,504 [ShotDetector] INFO  marytts.R 1 Next module: Utt2XML WordsEn
+2016-02-19 12:57:07,505 [ShotDetector] INFO  marytts.R 1 Next module: OpenNLPPosTagger
+2016-02-19 12:57:07,507 [ShotDetector] INFO  marytts.R 1 Next module: JPhonemiser
+2016-02-19 12:57:07,509 [ShotDetector] INFO  marytts.R 1 Next module: Prosody
+2016-02-19 12:57:07,520 [ShotDetector] INFO  marytts.R 1 Next module: PronunciationModel
+2016-02-19 12:57:07,521 [ShotDetector] INFO  marytts.R 1 Next module: AcousticModeller
+2016-02-19 12:57:07,542 [ShotDetector] INFO  marytts.ParameterGeneration Parameter generation for LF0: 
+2016-02-19 12:57:07,542 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 562
+2016-02-19 12:57:07,543 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=2
+2016-02-19 12:57:07,546 [ShotDetector] INFO  marytts.R 1 Next module: Synthesis
+2016-02-19 12:57:07,546 [ShotDetector] INFO  marytts.HMMSynthesizer Synthesizing one sentence.
+2016-02-19 12:57:07,547 [ShotDetector] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 12:57:07,548 [ShotDetector] INFO  marytts.HTSEngine Number of models in sentence numModel=32  Total number of states numState=160
+2016-02-19 12:57:07,548 [ShotDetector] INFO  marytts.HTSEngine Total number of frames=820  Number of voiced frames=562
+2016-02-19 12:57:07,553 [ShotDetector] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 12:57:07,554 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 814
+2016-02-19 12:57:07,562 [ShotDetector] INFO  marytts.PStream    optimization stopped by reaching max number of iterations (no global variance applied)
+2016-02-19 12:57:07,562 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=101
+2016-02-19 12:57:07,564 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=3
+2016-02-19 12:57:07,566 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=22
+2016-02-19 12:57:07,568 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=21
+2016-02-19 12:57:07,570 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=4
+2016-02-19 12:57:07,572 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=23
+2016-02-19 12:57:07,574 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=21
+2016-02-19 12:57:07,577 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=23
+2016-02-19 12:57:07,580 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=21
+2016-02-19 12:57:07,583 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 12:57:07,585 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=18
+2016-02-19 12:57:07,586 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=3
+2016-02-19 12:57:07,588 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=17
+2016-02-19 12:57:07,590 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=21
+2016-02-19 12:57:07,593 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=22
+2016-02-19 12:57:07,596 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=15
+2016-02-19 12:57:07,597 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=3
+2016-02-19 12:57:07,599 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=23
+2016-02-19 12:57:07,602 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=23
+2016-02-19 12:57:07,604 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=14
+2016-02-19 12:57:07,606 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=15
+2016-02-19 12:57:07,607 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=3
+2016-02-19 12:57:07,612 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=20
+2016-02-19 12:57:07,616 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=14
+2016-02-19 12:57:07,620 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=11
+2016-02-19 12:57:07,622 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=10
+2016-02-19 12:57:07,623 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=10
+2016-02-19 12:57:07,624 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=22
+2016-02-19 12:57:07,626 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=10
+2016-02-19 12:57:07,627 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=14
+2016-02-19 12:57:07,628 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=12
+2016-02-19 12:57:07,629 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=15
+2016-02-19 12:57:07,630 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=9
+2016-02-19 12:57:07,631 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 12:57:07,631 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=10
+2016-02-19 12:57:07,631 [ShotDetector] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 12:57:07,635 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 814
+2016-02-19 12:57:07,637 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=21
+2016-02-19 12:57:07,640 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=14
+2016-02-19 12:57:07,643 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=33
+2016-02-19 12:57:07,645 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=11
+2016-02-19 12:57:07,647 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=15
+2016-02-19 12:57:07,647 [ShotDetector] INFO  marytts.R 1 Request processed in 155 ms.
+2016-02-19 12:57:07,650 [ShotDetector] INFO  marytts.R 1    TextToMaryXML took 2 ms
+2016-02-19 12:57:07,650 [ShotDetector] INFO  marytts.R 1    JTokeniser took 1 ms
+2016-02-19 12:57:07,651 [ShotDetector] INFO  marytts.R 1    XML2Utt TokensEn took 1 ms
+2016-02-19 12:57:07,651 [ShotDetector] INFO  marytts.R 1    TokenToWords took 0 ms
+2016-02-19 12:57:07,651 [ShotDetector] INFO  marytts.R 1    Utt2XML WordsEn took 1 ms
+2016-02-19 12:57:07,651 [ShotDetector] INFO  marytts.R 1    OpenNLPPosTagger took 2 ms
+2016-02-19 12:57:07,651 [ShotDetector] INFO  marytts.R 1    JPhonemiser took 2 ms
+2016-02-19 12:57:07,651 [ShotDetector] INFO  marytts.R 1    Prosody took 11 ms
+2016-02-19 12:57:07,651 [ShotDetector] INFO  marytts.R 1    PronunciationModel took 1 ms
+2016-02-19 12:57:07,651 [ShotDetector] INFO  marytts.R 1    AcousticModeller took 25 ms
+2016-02-19 12:57:07,651 [ShotDetector] INFO  marytts.R 1    Synthesis took 101 ms
+2016-02-19 12:57:25,282 [ShotDetector] INFO  marytts.R 1 New request (input type "TEXT", output type "AUDIO", voice "cmu-slt-hsmm", audio "WAVE")
+2016-02-19 12:57:25,282 [ShotDetector] INFO  marytts.R 1 Handling request using the following modules:
+2016-02-19 12:57:25,283 [ShotDetector] INFO  marytts.R 1 - TextToMaryXML (marytts.modules.TextToMaryXML)
+2016-02-19 12:57:25,283 [ShotDetector] INFO  marytts.R 1 Next module: TextToMaryXML
+2016-02-19 12:57:25,284 [ShotDetector] INFO  marytts.R 1 Handling request using the following modules:
+2016-02-19 12:57:25,284 [ShotDetector] INFO  marytts.R 1 - JTokeniser (marytts.language.en.JTokeniser)
+2016-02-19 12:57:25,284 [ShotDetector] INFO  marytts.R 1 - XML2Utt TokensEn (marytts.language.en.XML2UttTokensEn)
+2016-02-19 12:57:25,284 [ShotDetector] INFO  marytts.R 1 - TokenToWords (marytts.language.en.FreeTTSTokenToWords)
+2016-02-19 12:57:25,284 [ShotDetector] INFO  marytts.R 1 - Utt2XML WordsEn (marytts.language.en.Utt2XMLWordsEn)
+2016-02-19 12:57:25,284 [ShotDetector] INFO  marytts.R 1 - OpenNLPPosTagger (marytts.modules.OpenNLPPosTagger)
+2016-02-19 12:57:25,284 [ShotDetector] INFO  marytts.R 1 - JPhonemiser (marytts.modules.JPhonemiser)
+2016-02-19 12:57:25,284 [ShotDetector] INFO  marytts.R 1 - Prosody (marytts.language.en.Prosody)
+2016-02-19 12:57:25,287 [ShotDetector] INFO  marytts.R 1 - PronunciationModel (marytts.language.en.PronunciationModel)
+2016-02-19 12:57:25,287 [ShotDetector] INFO  marytts.R 1 - AcousticModeller (marytts.modules.AcousticModeller)
+2016-02-19 12:57:25,287 [ShotDetector] INFO  marytts.R 1 - Synthesis (marytts.modules.Synthesis)
+2016-02-19 12:57:25,287 [ShotDetector] INFO  marytts.R 1 Next module: JTokeniser
+2016-02-19 12:57:25,290 [ShotDetector] INFO  marytts.R 1 Next module: XML2Utt TokensEn
+2016-02-19 12:57:25,290 [ShotDetector] INFO  marytts.R 1 Next module: TokenToWords
+2016-02-19 12:57:25,290 [ShotDetector] INFO  marytts.R 1 Next module: Utt2XML WordsEn
+2016-02-19 12:57:25,291 [ShotDetector] INFO  marytts.R 1 Next module: OpenNLPPosTagger
+2016-02-19 12:57:25,293 [ShotDetector] INFO  marytts.R 1 Next module: JPhonemiser
+2016-02-19 12:57:25,294 [ShotDetector] INFO  marytts.R 1 Next module: Prosody
+2016-02-19 12:57:25,296 [ShotDetector] INFO  marytts.R 1 Next module: PronunciationModel
+2016-02-19 12:57:25,297 [ShotDetector] INFO  marytts.R 1 Next module: AcousticModeller
+2016-02-19 12:57:25,312 [ShotDetector] INFO  marytts.ParameterGeneration Parameter generation for LF0: 
+2016-02-19 12:57:25,312 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 538
+2016-02-19 12:57:25,313 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=2
+2016-02-19 12:57:25,315 [ShotDetector] INFO  marytts.R 1 Next module: Synthesis
+2016-02-19 12:57:25,315 [ShotDetector] INFO  marytts.HMMSynthesizer Synthesizing one sentence.
+2016-02-19 12:57:25,316 [ShotDetector] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 12:57:25,317 [ShotDetector] INFO  marytts.HTSEngine Number of models in sentence numModel=32  Total number of states numState=160
+2016-02-19 12:57:25,317 [ShotDetector] INFO  marytts.HTSEngine Total number of frames=817  Number of voiced frames=538
+2016-02-19 12:57:25,320 [ShotDetector] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 12:57:25,320 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 811
+2016-02-19 12:57:25,325 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=64
+2016-02-19 12:57:25,328 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=23
+2016-02-19 12:57:25,329 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=6
+2016-02-19 12:57:25,331 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 12:57:25,332 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=2
+2016-02-19 12:57:25,334 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=23
+2016-02-19 12:57:25,335 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=4
+2016-02-19 12:57:25,338 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=23
+2016-02-19 12:57:25,340 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=26
+2016-02-19 12:57:25,343 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 12:57:25,346 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=8
+2016-02-19 12:57:25,347 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=3
+2016-02-19 12:57:25,349 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=17
+2016-02-19 12:57:25,351 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=16
+2016-02-19 12:57:25,353 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=18
+2016-02-19 12:57:25,355 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=16
+2016-02-19 12:57:25,356 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=4
+2016-02-19 12:57:25,359 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=24
+2016-02-19 12:57:25,362 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=23
+2016-02-19 12:57:25,364 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 12:57:25,366 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=15
+2016-02-19 12:57:25,367 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=4
+2016-02-19 12:57:25,369 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=20
+2016-02-19 12:57:25,371 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=15
+2016-02-19 12:57:25,372 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=9
+2016-02-19 12:57:25,374 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=10
+2016-02-19 12:57:25,376 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=17
+2016-02-19 12:57:25,378 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=14
+2016-02-19 12:57:25,379 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=10
+2016-02-19 12:57:25,380 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=14
+2016-02-19 12:57:25,381 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=12
+2016-02-19 12:57:25,382 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=14
+2016-02-19 12:57:25,383 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 12:57:25,384 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=9
+2016-02-19 12:57:25,387 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=33
+2016-02-19 12:57:25,387 [ShotDetector] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 12:57:25,390 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 811
+2016-02-19 12:57:25,394 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=62
+2016-02-19 12:57:25,395 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=14
+2016-02-19 12:57:25,398 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=33
+2016-02-19 12:57:25,399 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=10
+2016-02-19 12:57:25,402 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=32
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1 Request processed in 121 ms.
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1    TextToMaryXML took 0 ms
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1    JTokeniser took 3 ms
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1    XML2Utt TokensEn took 0 ms
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1    TokenToWords took 0 ms
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1    Utt2XML WordsEn took 1 ms
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1    OpenNLPPosTagger took 2 ms
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1    JPhonemiser took 1 ms
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1    Prosody took 2 ms
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1    PronunciationModel took 1 ms
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1    AcousticModeller took 18 ms
+2016-02-19 12:57:25,403 [ShotDetector] INFO  marytts.R 1    Synthesis took 88 ms
+2016-02-19 12:57:42,493 [ShotDetector] INFO  marytts.R 1 New request (input type "TEXT", output type "AUDIO", voice "cmu-slt-hsmm", audio "WAVE")
+2016-02-19 12:57:42,494 [ShotDetector] INFO  marytts.R 1 Handling request using the following modules:
+2016-02-19 12:57:42,494 [ShotDetector] INFO  marytts.R 1 - TextToMaryXML (marytts.modules.TextToMaryXML)
+2016-02-19 12:57:42,494 [ShotDetector] INFO  marytts.R 1 Next module: TextToMaryXML
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 Handling request using the following modules:
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 - JTokeniser (marytts.language.en.JTokeniser)
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 - XML2Utt TokensEn (marytts.language.en.XML2UttTokensEn)
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 - TokenToWords (marytts.language.en.FreeTTSTokenToWords)
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 - Utt2XML WordsEn (marytts.language.en.Utt2XMLWordsEn)
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 - OpenNLPPosTagger (marytts.modules.OpenNLPPosTagger)
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 - JPhonemiser (marytts.modules.JPhonemiser)
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 - Prosody (marytts.language.en.Prosody)
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 - PronunciationModel (marytts.language.en.PronunciationModel)
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 - AcousticModeller (marytts.modules.AcousticModeller)
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 - Synthesis (marytts.modules.Synthesis)
+2016-02-19 12:57:42,495 [ShotDetector] INFO  marytts.R 1 Next module: JTokeniser
+2016-02-19 12:57:42,496 [ShotDetector] INFO  marytts.R 1 Next module: XML2Utt TokensEn
+2016-02-19 12:57:42,496 [ShotDetector] INFO  marytts.R 1 Next module: TokenToWords
+2016-02-19 12:57:42,496 [ShotDetector] INFO  marytts.R 1 Next module: Utt2XML WordsEn
+2016-02-19 12:57:42,497 [ShotDetector] INFO  marytts.R 1 Next module: OpenNLPPosTagger
+2016-02-19 12:57:42,504 [ShotDetector] INFO  marytts.R 1 Next module: JPhonemiser
+2016-02-19 12:57:42,507 [ShotDetector] INFO  marytts.R 1 Next module: Prosody
+2016-02-19 12:57:42,509 [ShotDetector] INFO  marytts.R 1 Next module: PronunciationModel
+2016-02-19 12:57:42,510 [ShotDetector] INFO  marytts.R 1 Next module: AcousticModeller
+2016-02-19 12:57:42,526 [ShotDetector] INFO  marytts.ParameterGeneration Parameter generation for LF0: 
+2016-02-19 12:57:42,526 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 541
+2016-02-19 12:57:42,527 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=2
+2016-02-19 12:57:42,529 [ShotDetector] INFO  marytts.R 1 Next module: Synthesis
+2016-02-19 12:57:42,529 [ShotDetector] INFO  marytts.HMMSynthesizer Synthesizing one sentence.
+2016-02-19 12:57:42,530 [ShotDetector] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 12:57:42,531 [ShotDetector] INFO  marytts.HTSEngine Number of models in sentence numModel=32  Total number of states numState=160
+2016-02-19 12:57:42,532 [ShotDetector] INFO  marytts.HTSEngine Total number of frames=817  Number of voiced frames=541
+2016-02-19 12:57:42,535 [ShotDetector] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 12:57:42,535 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 811
+2016-02-19 12:57:42,539 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=64
+2016-02-19 12:57:42,541 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=8
+2016-02-19 12:57:42,542 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=6
+2016-02-19 12:57:42,543 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=7
+2016-02-19 12:57:42,545 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=2
+2016-02-19 12:57:42,547 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=23
+2016-02-19 12:57:42,548 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=3
+2016-02-19 12:57:42,550 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=23
+2016-02-19 12:57:42,552 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=26
+2016-02-19 12:57:42,553 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=18
+2016-02-19 12:57:42,555 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=18
+2016-02-19 12:57:42,556 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=3
+2016-02-19 12:57:42,558 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=17
+2016-02-19 12:57:42,560 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=17
+2016-02-19 12:57:42,561 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=19
+2016-02-19 12:57:42,563 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=15
+2016-02-19 12:57:42,564 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=4
+2016-02-19 12:57:42,567 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=23
+2016-02-19 12:57:42,569 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=23
+2016-02-19 12:57:42,570 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=13
+2016-02-19 12:57:42,572 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=15
+2016-02-19 12:57:42,573 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=4
+2016-02-19 12:57:42,575 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=20
+2016-02-19 12:57:42,576 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=16
+2016-02-19 12:57:42,577 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=10
+2016-02-19 12:57:42,578 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=10
+2016-02-19 12:57:42,579 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=16
+2016-02-19 12:57:42,580 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=15
+2016-02-19 12:57:42,582 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=10
+2016-02-19 12:57:42,583 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=14
+2016-02-19 12:57:42,584 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=12
+2016-02-19 12:57:42,586 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=14
+2016-02-19 12:57:42,587 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=8
+2016-02-19 12:57:42,588 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=9
+2016-02-19 12:57:42,588 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=15
+2016-02-19 12:57:42,589 [ShotDetector] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 12:57:42,591 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 811
+2016-02-19 12:57:42,595 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=65
+2016-02-19 12:57:42,596 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=14
+2016-02-19 12:57:42,599 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=33
+2016-02-19 12:57:42,600 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 12:57:42,601 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=40
+2016-02-19 12:57:42,602 [ShotDetector] INFO  marytts.R 1 Request processed in 109 ms.
+2016-02-19 12:57:42,602 [ShotDetector] INFO  marytts.R 1    TextToMaryXML took 0 ms
+2016-02-19 12:57:42,602 [ShotDetector] INFO  marytts.R 1    JTokeniser took 1 ms
+2016-02-19 12:57:42,602 [ShotDetector] INFO  marytts.R 1    XML2Utt TokensEn took 0 ms
+2016-02-19 12:57:42,602 [ShotDetector] INFO  marytts.R 1    TokenToWords took 0 ms
+2016-02-19 12:57:42,602 [ShotDetector] INFO  marytts.R 1    Utt2XML WordsEn took 1 ms
+2016-02-19 12:57:42,602 [ShotDetector] INFO  marytts.R 1    OpenNLPPosTagger took 7 ms
+2016-02-19 12:57:42,602 [ShotDetector] INFO  marytts.R 1    JPhonemiser took 3 ms
+2016-02-19 12:57:42,602 [ShotDetector] INFO  marytts.R 1    Prosody took 2 ms
+2016-02-19 12:57:42,602 [ShotDetector] INFO  marytts.R 1    PronunciationModel took 1 ms
+2016-02-19 12:57:42,602 [ShotDetector] INFO  marytts.R 1    AcousticModeller took 19 ms
+2016-02-19 12:57:42,603 [ShotDetector] INFO  marytts.R 1    Synthesis took 73 ms
+2016-02-19 12:57:59,620 [ShotDetector] INFO  marytts.R 1 New request (input type "TEXT", output type "AUDIO", voice "cmu-slt-hsmm", audio "WAVE")
+2016-02-19 12:57:59,620 [ShotDetector] INFO  marytts.R 1 Handling request using the following modules:
+2016-02-19 12:57:59,620 [ShotDetector] INFO  marytts.R 1 - TextToMaryXML (marytts.modules.TextToMaryXML)
+2016-02-19 12:57:59,620 [ShotDetector] INFO  marytts.R 1 Next module: TextToMaryXML
+2016-02-19 12:57:59,621 [ShotDetector] INFO  marytts.R 1 Handling request using the following modules:
+2016-02-19 12:57:59,621 [ShotDetector] INFO  marytts.R 1 - JTokeniser (marytts.language.en.JTokeniser)
+2016-02-19 12:57:59,621 [ShotDetector] INFO  marytts.R 1 - XML2Utt TokensEn (marytts.language.en.XML2UttTokensEn)
+2016-02-19 12:57:59,621 [ShotDetector] INFO  marytts.R 1 - TokenToWords (marytts.language.en.FreeTTSTokenToWords)
+2016-02-19 12:57:59,621 [ShotDetector] INFO  marytts.R 1 - Utt2XML WordsEn (marytts.language.en.Utt2XMLWordsEn)
+2016-02-19 12:57:59,622 [ShotDetector] INFO  marytts.R 1 - OpenNLPPosTagger (marytts.modules.OpenNLPPosTagger)
+2016-02-19 12:57:59,622 [ShotDetector] INFO  marytts.R 1 - JPhonemiser (marytts.modules.JPhonemiser)
+2016-02-19 12:57:59,622 [ShotDetector] INFO  marytts.R 1 - Prosody (marytts.language.en.Prosody)
+2016-02-19 12:57:59,622 [ShotDetector] INFO  marytts.R 1 - PronunciationModel (marytts.language.en.PronunciationModel)
+2016-02-19 12:57:59,622 [ShotDetector] INFO  marytts.R 1 - AcousticModeller (marytts.modules.AcousticModeller)
+2016-02-19 12:57:59,622 [ShotDetector] INFO  marytts.R 1 - Synthesis (marytts.modules.Synthesis)
+2016-02-19 12:57:59,622 [ShotDetector] INFO  marytts.R 1 Next module: JTokeniser
+2016-02-19 12:57:59,623 [ShotDetector] INFO  marytts.R 1 Next module: XML2Utt TokensEn
+2016-02-19 12:57:59,624 [ShotDetector] INFO  marytts.R 1 Next module: TokenToWords
+2016-02-19 12:57:59,625 [ShotDetector] INFO  marytts.R 1 Next module: Utt2XML WordsEn
+2016-02-19 12:57:59,626 [ShotDetector] INFO  marytts.R 1 Next module: OpenNLPPosTagger
+2016-02-19 12:57:59,628 [ShotDetector] INFO  marytts.R 1 Next module: JPhonemiser
+2016-02-19 12:57:59,629 [ShotDetector] INFO  marytts.R 1 Next module: Prosody
+2016-02-19 12:57:59,631 [ShotDetector] INFO  marytts.R 1 Next module: PronunciationModel
+2016-02-19 12:57:59,632 [ShotDetector] INFO  marytts.R 1 Next module: AcousticModeller
+2016-02-19 12:57:59,649 [ShotDetector] INFO  marytts.ParameterGeneration Parameter generation for LF0: 
+2016-02-19 12:57:59,650 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 572
+2016-02-19 12:57:59,650 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=2
+2016-02-19 12:57:59,653 [ShotDetector] INFO  marytts.R 1 Next module: Synthesis
+2016-02-19 12:57:59,654 [ShotDetector] INFO  marytts.HMMSynthesizer Synthesizing one sentence.
+2016-02-19 12:57:59,654 [ShotDetector] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 12:57:59,656 [ShotDetector] INFO  marytts.HTSEngine Number of models in sentence numModel=30  Total number of states numState=150
+2016-02-19 12:57:59,656 [ShotDetector] INFO  marytts.HTSEngine Total number of frames=772  Number of voiced frames=572
+2016-02-19 12:57:59,659 [ShotDetector] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 12:57:59,659 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 766
+2016-02-19 12:57:59,665 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=95
+2016-02-19 12:57:59,667 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=25
+2016-02-19 12:57:59,669 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=22
+2016-02-19 12:57:59,670 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=5
+2016-02-19 12:57:59,671 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=21
+2016-02-19 12:57:59,673 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=23
+2016-02-19 12:57:59,674 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=5
+2016-02-19 12:57:59,676 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=21
+2016-02-19 12:57:59,678 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=22
+2016-02-19 12:57:59,680 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=23
+2016-02-19 12:57:59,682 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=19
+2016-02-19 12:57:59,683 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=3
+2016-02-19 12:57:59,684 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=17
+2016-02-19 12:57:59,686 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=16
+2016-02-19 12:57:59,688 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=26
+2016-02-19 12:57:59,689 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=16
+2016-02-19 12:57:59,690 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=3
+2016-02-19 12:57:59,692 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=17
+2016-02-19 12:57:59,693 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=15
+2016-02-19 12:57:59,695 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=9
+2016-02-19 12:57:59,696 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=16
+2016-02-19 12:57:59,697 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=3
+2016-02-19 12:57:59,700 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=20
+2016-02-19 12:57:59,701 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=15
+2016-02-19 12:57:59,702 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=10
+2016-02-19 12:57:59,703 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=10
+2016-02-19 12:57:59,706 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=9
+2016-02-19 12:57:59,708 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=15
+2016-02-19 12:57:59,709 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=9
+2016-02-19 12:57:59,712 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=14
+2016-02-19 12:57:59,713 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=12
+2016-02-19 12:57:59,715 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=15
+2016-02-19 12:57:59,716 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=8
+2016-02-19 12:57:59,717 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=7
+2016-02-19 12:57:59,718 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=18
+2016-02-19 12:57:59,718 [ShotDetector] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 12:57:59,722 [ShotDetector] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 766
+2016-02-19 12:57:59,727 [ShotDetector] INFO  marytts.PStream    optimization stopped by reaching max number of iterations (no global variance applied)
+2016-02-19 12:57:59,728 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=101
+2016-02-19 12:57:59,732 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=24
+2016-02-19 12:57:59,733 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=3
+2016-02-19 12:57:59,735 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=9
+2016-02-19 12:57:59,737 [ShotDetector] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=3
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1 Request processed in 118 ms.
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1    TextToMaryXML took 0 ms
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1    JTokeniser took 1 ms
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1    XML2Utt TokensEn took 1 ms
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1    TokenToWords took 1 ms
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1    Utt2XML WordsEn took 1 ms
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1    OpenNLPPosTagger took 2 ms
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1    JPhonemiser took 1 ms
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1    Prosody took 2 ms
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1    PronunciationModel took 1 ms
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1    AcousticModeller took 21 ms
+2016-02-19 12:57:59,738 [ShotDetector] INFO  marytts.R 1    Synthesis took 85 ms
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 12:58:12,406 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 13:25:55,007 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 13:25:55,011 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 13:25:55,011 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 13:25:55,011 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 13:25:55,164 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 13:25:55,169 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 13:25:55,170 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 13:25:55,171 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 13:25:55,172 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 13:25:55,173 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 13:25:55,174 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 13:25:55,175 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 13:25:55,176 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 13:25:55,180 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 13:25:55,182 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 13:25:55,183 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 13:25:55,183 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 13:25:55,184 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 13:25:55,185 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 13:25:55,185 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 13:25:55,187 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 13:25:55,189 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 13:25:55,190 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 13:25:55,195 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 13:25:55,196 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 13:25:55,291 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 13:25:55,291 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 13:25:55,356 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 13:25:55,357 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 13:25:55,358 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 13:25:55,362 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 13:25:55,367 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 13:25:55,368 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 13:25:55,373 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 13:25:55,374 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 13:25:55,374 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 13:25:55,407 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 13:25:55,506 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 13:25:55,720 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 13:25:55,734 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 13:25:55,735 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 13:25:55,735 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 13:25:55,735 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 13:25:55,772 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 13:25:55,775 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 13:25:55,775 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 13:25:55,783 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 13:25:55,783 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 13:25:55,790 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 13:25:55,807 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 13:25:55,814 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 13:25:55,817 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 13:25:55,819 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 13:25:55,821 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 13:25:55,824 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 13:25:55,826 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 13:25:55,827 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 13:25:55,829 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 13:25:55,830 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 13:25:55,831 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 13:25:55,831 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 13:25:55,832 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 13:25:55,833 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 13:25:55,834 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 13:25:55,835 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 13:25:55,837 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 13:25:55,838 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 13:25:55,839 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 13:25:55,840 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 13:25:55,842 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 13:25:55,843 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 13:25:55,844 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 13:25:55,845 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 13:25:55,846 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 13:25:55,847 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 13:25:55,848 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 13:25:55,849 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 13:25:55,850 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 13:25:55,851 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 13:25:55,852 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 13:25:55,853 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 13:25:55,854 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 13:25:55,855 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 13:25:55,855 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 13:25:55,858 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 13:25:55,860 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 13:25:55,860 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 13:25:55,861 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 13:25:55,862 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 13:25:55,864 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 13:25:55,873 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 13:25:55,875 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 13:25:55,875 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 13:25:55,876 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 13:25:55,876 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 13:25:55,876 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 13:25:56,177 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 13:25:56,177 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 13:25:56,177 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 13:25:56,278 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 13:25:56,278 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 13:25:56,278 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 13:25:56,376 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 13:25:56,376 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 13:25:56,377 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 13:25:56,450 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 13:25:56,453 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 13:25:56,453 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 13:25:56,453 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 13:25:56,512 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 13:25:56,512 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 13:25:56,512 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 13:25:56,512 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 13:25:56,512 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 13:25:56,521 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 13:25:56,521 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 13:25:56,521 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 13:25:56,521 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 13:25:56,521 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 13:25:56,522 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 13:25:56,522 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 13:25:56,522 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 13:25:56,522 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 13:25:56,522 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 13:25:56,522 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 13:25:56,522 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 13:25:56,523 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 13:25:56,523 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 13:25:56,523 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 13:25:56,523 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 13:25:56,523 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 13:25:56,523 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 13:25:56,523 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 13:25:56,524 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 13:25:56,524 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 13:25:56,524 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 13:25:56,524 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 13:25:56,524 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 13:25:56,547 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 13:25:56,548 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 13:25:56,548 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 13:25:56,564 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 13:25:56,564 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 13:25:56,564 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 13:25:56,564 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 13:25:56,565 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 13:25:56,565 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 13:25:56,565 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 13:25:56,565 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 13:25:56,572 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 13:25:56,572 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 13:25:56,572 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 13:25:56,573 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 13:25:56,573 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 13:25:56,576 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 13:25:56,577 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 13:25:56,577 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 13:25:56,577 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 13:25:56,577 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 13:25:56,577 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 13:25:56,578 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 13:25:56,578 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 13:25:56,578 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 13:25:56,578 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 13:25:56,578 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 13:25:57,787 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 13:25:57,787 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 13:25:57,787 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 13:26:24,206 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 13:26:24,206 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 13:26:24,206 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 13:26:24,206 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 13:26:24,206 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 13:26:24,207 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 13:26:24,207 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 13:26:24,207 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 13:26:24,207 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 13:26:24,207 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 13:26:24,207 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 13:26:24,207 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 13:26:24,207 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 13:26:24,207 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 13:26:24,208 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 13:26:24,210 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 13:43:44,547 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 13:43:44,552 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 13:43:44,552 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 13:43:44,552 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 13:43:44,658 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 13:43:44,664 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 13:43:44,665 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 13:43:44,666 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 13:43:44,666 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 13:43:44,667 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 13:43:44,668 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 13:43:44,669 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 13:43:44,670 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 13:43:44,674 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 13:43:44,675 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 13:43:44,676 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 13:43:44,676 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 13:43:44,678 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 13:43:44,678 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 13:43:44,679 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 13:43:44,680 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 13:43:44,683 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 13:43:44,683 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 13:43:44,687 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 13:43:44,688 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 13:43:44,763 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 13:43:44,763 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 13:43:44,823 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 13:43:44,824 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 13:43:44,825 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 13:43:44,828 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 13:43:44,834 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 13:43:44,835 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 13:43:44,842 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 13:43:44,843 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 13:43:44,843 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 13:43:44,877 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 13:43:44,987 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 13:43:45,202 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 13:43:45,217 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 13:43:45,217 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 13:43:45,218 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 13:43:45,218 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 13:43:45,252 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 13:43:45,256 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 13:43:45,256 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 13:43:45,264 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 13:43:45,264 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 13:43:45,272 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 13:43:45,290 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 13:43:45,297 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 13:43:45,300 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 13:43:45,302 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 13:43:45,305 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 13:43:45,307 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 13:43:45,309 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 13:43:45,311 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 13:43:45,313 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 13:43:45,314 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 13:43:45,315 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 13:43:45,315 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 13:43:45,316 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 13:43:45,317 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 13:43:45,318 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 13:43:45,319 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 13:43:45,320 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 13:43:45,322 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 13:43:45,323 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 13:43:45,324 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 13:43:45,326 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 13:43:45,326 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 13:43:45,328 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 13:43:45,329 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 13:43:45,330 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 13:43:45,331 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 13:43:45,332 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 13:43:45,333 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 13:43:45,334 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 13:43:45,335 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 13:43:45,337 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 13:43:45,338 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 13:43:45,339 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 13:43:45,339 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 13:43:45,339 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 13:43:45,341 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 13:43:45,342 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 13:43:45,342 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 13:43:45,343 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 13:43:45,343 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 13:43:45,344 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 13:43:45,354 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 13:43:45,355 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 13:43:45,355 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 13:43:45,356 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 13:43:45,356 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 13:43:45,357 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 13:43:45,630 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 13:43:45,630 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 13:43:45,631 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 13:43:45,728 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 13:43:45,728 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 13:43:45,728 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 13:43:45,812 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 13:43:45,813 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 13:43:45,813 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 13:43:45,875 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 13:43:45,875 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 13:43:45,875 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 13:43:45,875 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 13:43:45,921 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 13:43:45,921 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 13:43:45,921 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 13:43:45,921 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 13:43:45,921 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 13:43:45,929 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 13:43:45,929 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 13:43:45,929 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 13:43:45,929 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 13:43:45,930 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 13:43:45,930 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 13:43:45,930 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 13:43:45,930 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 13:43:45,930 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 13:43:45,930 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 13:43:45,931 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 13:43:45,931 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 13:43:45,931 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 13:43:45,931 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 13:43:45,931 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 13:43:45,931 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 13:43:45,931 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 13:43:45,931 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 13:43:45,932 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 13:43:45,932 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 13:43:45,932 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 13:43:45,932 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 13:43:45,932 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 13:43:45,932 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 13:43:45,953 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 13:43:45,953 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 13:43:45,953 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 13:43:45,970 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 13:43:45,971 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 13:43:45,971 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 13:43:45,971 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 13:43:45,971 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 13:43:45,971 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 13:43:45,971 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 13:43:45,971 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 13:43:45,979 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 13:43:45,979 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 13:43:45,979 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 13:43:45,980 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 13:43:45,980 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 13:43:45,983 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 13:43:45,984 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 13:43:45,984 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 13:43:45,984 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 13:43:45,984 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 13:43:45,984 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 13:43:45,985 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 13:43:45,985 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 13:43:45,985 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 13:43:45,985 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 13:43:45,985 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 13:43:47,187 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 13:43:47,187 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 13:43:47,188 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 13:45:32,871 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 13:45:32,871 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 13:45:32,872 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 13:45:32,872 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 13:45:32,872 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 13:45:32,872 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 13:45:32,874 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 13:45:32,874 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 13:45:32,874 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 13:45:32,874 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 13:45:32,874 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 13:45:32,874 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 13:45:32,874 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 13:45:32,875 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 13:45:32,875 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 13:45:32,875 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 13:45:32,875 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 13:45:32,875 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 13:45:32,875 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 13:45:32,875 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 13:45:32,875 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 13:45:32,875 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 13:45:32,875 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 13:45:32,875 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 13:45:32,876 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 13:45:32,876 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 13:45:32,876 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 13:45:32,876 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 13:45:32,878 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 13:46:19,857 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 13:46:19,860 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 13:46:19,860 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 13:46:19,860 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 13:46:19,947 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 13:46:19,951 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 13:46:19,952 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 13:46:19,953 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 13:46:19,953 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 13:46:19,954 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 13:46:19,954 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 13:46:19,955 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 13:46:19,956 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 13:46:19,958 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 13:46:19,959 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 13:46:19,960 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 13:46:19,961 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 13:46:19,962 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 13:46:19,962 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 13:46:19,963 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 13:46:19,965 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 13:46:19,967 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 13:46:19,967 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 13:46:19,971 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 13:46:19,972 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 13:46:20,045 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 13:46:20,045 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 13:46:20,103 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 13:46:20,104 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 13:46:20,105 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 13:46:20,109 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 13:46:20,114 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 13:46:20,115 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 13:46:20,122 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 13:46:20,123 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 13:46:20,123 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 13:46:20,155 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 13:46:20,244 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 13:46:20,446 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 13:46:20,462 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 13:46:20,462 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 13:46:20,462 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 13:46:20,463 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 13:46:20,497 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 13:46:20,500 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 13:46:20,500 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 13:46:20,508 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 13:46:20,508 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 13:46:20,515 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 13:46:20,531 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 13:46:20,537 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 13:46:20,539 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 13:46:20,541 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 13:46:20,543 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 13:46:20,545 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 13:46:20,547 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 13:46:20,548 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 13:46:20,550 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 13:46:20,551 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 13:46:20,552 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 13:46:20,553 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 13:46:20,554 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 13:46:20,555 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 13:46:20,556 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 13:46:20,557 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 13:46:20,558 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 13:46:20,559 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 13:46:20,560 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 13:46:20,561 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 13:46:20,563 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 13:46:20,564 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 13:46:20,565 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 13:46:20,566 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 13:46:20,567 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 13:46:20,568 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 13:46:20,569 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 13:46:20,570 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 13:46:20,571 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 13:46:20,572 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 13:46:20,573 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 13:46:20,574 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 13:46:20,575 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 13:46:20,576 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 13:46:20,576 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 13:46:20,577 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 13:46:20,578 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 13:46:20,579 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 13:46:20,580 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 13:46:20,581 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 13:46:20,582 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 13:46:20,590 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 13:46:20,592 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 13:46:20,592 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 13:46:20,595 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 13:46:20,596 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 13:46:20,596 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 13:46:20,853 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 13:46:20,853 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 13:46:20,854 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 13:46:20,960 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 13:46:20,960 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 13:46:20,960 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 13:46:21,046 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 13:46:21,047 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 13:46:21,047 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 13:46:21,106 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 13:46:21,106 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 13:46:21,107 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 13:46:21,107 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 13:46:21,152 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 13:46:21,153 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 13:46:21,153 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 13:46:21,153 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 13:46:21,153 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 13:46:21,160 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 13:46:21,160 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 13:46:21,161 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 13:46:21,161 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 13:46:21,161 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 13:46:21,161 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 13:46:21,161 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 13:46:21,161 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 13:46:21,162 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 13:46:21,162 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 13:46:21,162 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 13:46:21,162 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 13:46:21,162 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 13:46:21,162 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 13:46:21,162 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 13:46:21,162 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 13:46:21,163 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 13:46:21,163 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 13:46:21,163 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 13:46:21,163 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 13:46:21,163 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 13:46:21,163 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 13:46:21,163 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 13:46:21,163 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 13:46:21,194 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 13:46:21,194 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 13:46:21,194 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 13:46:21,211 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 13:46:21,211 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 13:46:21,211 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 13:46:21,212 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 13:46:21,212 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 13:46:21,212 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 13:46:21,212 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 13:46:21,212 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 13:46:21,220 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 13:46:21,220 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 13:46:21,220 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 13:46:21,221 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 13:46:21,221 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 13:46:21,224 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 13:46:21,225 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 13:46:21,225 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 13:46:21,226 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 13:46:21,226 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 13:46:21,226 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 13:46:21,226 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 13:46:21,226 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 13:46:21,226 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 13:46:21,226 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 13:46:21,227 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 13:46:22,393 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 13:46:22,393 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 13:46:22,394 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 13:52:55,346 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 13:52:55,352 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 13:52:55,352 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 13:52:55,352 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 13:52:55,449 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 13:52:55,454 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 13:52:55,455 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 13:52:55,456 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 13:52:55,456 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 13:52:55,457 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 13:52:55,457 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 13:52:55,458 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 13:52:55,459 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 13:52:55,462 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 13:52:55,463 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 13:52:55,464 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 13:52:55,464 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 13:52:55,465 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 13:52:55,466 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 13:52:55,466 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 13:52:55,468 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 13:52:55,470 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 13:52:55,470 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 13:52:55,474 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 13:52:55,475 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 13:52:55,550 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 13:52:55,550 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 13:52:55,606 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 13:52:55,607 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 13:52:55,609 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 13:52:55,612 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 13:52:55,617 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 13:52:55,618 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 13:52:55,624 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 13:52:55,625 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 13:52:55,626 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 13:52:55,670 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 13:52:55,784 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 13:52:56,019 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 13:52:56,033 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 13:52:56,033 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 13:52:56,033 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 13:52:56,034 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 13:52:56,073 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 13:52:56,077 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 13:52:56,077 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 13:52:56,087 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 13:52:56,087 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 13:52:56,094 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 13:52:56,111 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 13:52:56,124 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 13:52:56,127 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 13:52:56,130 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 13:52:56,132 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 13:52:56,134 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 13:52:56,136 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 13:52:56,138 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 13:52:56,139 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 13:52:56,141 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 13:52:56,142 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 13:52:56,142 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 13:52:56,143 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 13:52:56,144 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 13:52:56,145 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 13:52:56,146 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 13:52:56,147 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 13:52:56,148 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 13:52:56,149 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 13:52:56,150 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 13:52:56,152 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 13:52:56,153 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 13:52:56,154 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 13:52:56,155 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 13:52:56,156 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 13:52:56,157 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 13:52:56,161 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 13:52:56,165 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 13:52:56,166 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 13:52:56,166 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 13:52:56,166 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 13:52:56,167 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 13:52:56,167 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 13:52:56,168 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 13:52:56,168 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 13:52:56,169 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 13:52:56,170 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 13:52:56,170 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 13:52:56,171 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 13:52:56,171 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 13:52:56,172 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 13:52:56,178 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 13:52:56,179 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 13:52:56,180 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 13:52:56,181 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 13:52:56,181 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 13:52:56,181 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 13:52:56,468 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 13:52:56,469 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 13:52:56,469 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 13:52:56,587 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 13:52:56,588 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 13:52:56,588 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 13:52:56,686 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 13:52:56,686 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 13:52:56,687 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 13:52:56,808 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 13:52:56,808 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 13:52:56,809 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 13:52:56,809 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 13:52:56,911 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 13:52:56,911 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 13:52:56,911 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 13:52:56,911 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 13:52:56,911 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 13:52:56,919 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 13:52:56,920 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 13:52:56,920 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 13:52:56,920 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 13:52:56,920 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 13:52:56,920 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 13:52:56,920 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 13:52:56,921 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 13:52:56,921 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 13:52:56,921 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 13:52:56,921 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 13:52:56,921 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 13:52:56,921 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 13:52:56,921 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 13:52:56,921 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 13:52:56,921 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 13:52:56,922 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 13:52:56,922 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 13:52:56,922 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 13:52:56,922 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 13:52:56,922 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 13:52:56,922 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 13:52:56,922 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 13:52:56,922 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 13:52:56,954 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 13:52:56,954 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 13:52:56,954 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 13:52:56,971 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 13:52:56,972 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 13:52:56,972 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 13:52:56,972 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 13:52:56,972 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 13:52:56,972 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 13:52:56,972 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 13:52:56,973 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 13:52:56,981 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 13:52:56,981 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 13:52:56,981 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 13:52:56,982 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 13:52:56,983 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 13:52:56,997 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 13:52:56,998 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 13:52:56,998 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 13:52:56,998 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 13:52:56,998 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 13:52:56,998 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 13:52:56,998 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 13:52:56,998 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 13:52:56,998 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 13:52:56,999 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 13:52:56,999 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 13:52:58,357 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 13:52:58,357 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 13:52:58,358 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 13:53:01,344 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 13:53:01,345 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 13:53:01,346 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 13:53:01,348 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 13:53:01,353 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 13:53:05,108 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 13:53:05,108 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 13:53:05,108 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 13:53:05,108 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 13:53:05,108 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 13:53:05,108 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 13:53:05,108 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 13:53:05,108 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 13:53:05,108 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 13:53:05,109 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 13:53:05,111 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 13:53:09,499 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 13:53:09,502 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 13:53:09,503 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 13:53:09,503 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 13:53:09,591 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 13:53:09,596 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 13:53:09,597 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 13:53:09,597 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 13:53:09,598 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 13:53:09,598 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 13:53:09,599 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 13:53:09,600 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 13:53:09,600 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 13:53:09,603 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 13:53:09,604 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 13:53:09,605 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 13:53:09,605 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 13:53:09,606 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 13:53:09,607 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 13:53:09,607 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 13:53:09,609 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 13:53:09,611 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 13:53:09,612 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 13:53:09,615 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 13:53:09,616 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 13:53:09,690 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 13:53:09,690 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 13:53:09,749 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 13:53:09,750 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 13:53:09,752 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 13:53:09,755 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 13:53:09,761 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 13:53:09,762 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 13:53:09,768 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 13:53:09,770 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 13:53:09,770 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 13:53:09,801 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 13:53:09,906 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 13:53:10,108 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 13:53:10,119 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 13:53:10,119 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 13:53:10,119 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 13:53:10,120 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 13:53:10,151 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 13:53:10,154 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 13:53:10,154 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 13:53:10,162 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 13:53:10,162 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 13:53:10,170 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 13:53:10,187 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 13:53:10,194 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 13:53:10,195 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 13:53:10,197 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 13:53:10,199 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 13:53:10,200 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 13:53:10,202 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 13:53:10,203 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 13:53:10,204 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 13:53:10,205 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 13:53:10,205 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 13:53:10,206 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 13:53:10,206 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 13:53:10,207 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 13:53:10,208 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 13:53:10,209 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 13:53:10,210 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 13:53:10,211 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 13:53:10,212 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 13:53:10,213 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 13:53:10,215 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 13:53:10,216 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 13:53:10,217 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 13:53:10,218 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 13:53:10,219 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 13:53:10,221 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 13:53:10,222 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 13:53:10,223 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 13:53:10,223 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 13:53:10,225 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 13:53:10,225 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 13:53:10,226 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 13:53:10,227 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 13:53:10,228 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 13:53:10,228 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 13:53:10,230 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 13:53:10,231 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 13:53:10,232 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 13:53:10,232 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 13:53:10,233 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 13:53:10,235 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 13:53:10,244 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 13:53:10,245 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 13:53:10,245 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 13:53:10,248 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 13:53:10,248 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 13:53:10,249 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 13:53:10,498 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 13:53:10,498 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 13:53:10,498 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 13:53:10,604 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 13:53:10,605 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 13:53:10,605 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 13:53:10,689 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 13:53:10,689 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 13:53:10,690 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 13:53:10,757 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 13:53:10,757 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 13:53:10,757 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 13:53:10,757 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 13:53:10,805 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 13:53:10,805 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 13:53:10,805 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 13:53:10,805 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 13:53:10,806 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 13:53:10,813 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 13:53:10,813 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 13:53:10,813 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 13:53:10,813 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 13:53:10,813 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 13:53:10,813 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 13:53:10,814 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 13:53:10,814 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 13:53:10,814 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 13:53:10,814 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 13:53:10,814 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 13:53:10,814 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 13:53:10,814 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 13:53:10,814 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 13:53:10,815 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 13:53:10,815 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 13:53:10,815 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 13:53:10,815 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 13:53:10,815 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 13:53:10,815 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 13:53:10,815 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 13:53:10,815 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 13:53:10,815 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 13:53:10,816 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 13:53:10,838 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 13:53:10,838 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 13:53:10,838 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 13:53:10,854 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 13:53:10,854 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 13:53:10,854 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 13:53:10,854 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 13:53:10,854 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 13:53:10,854 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 13:53:10,854 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 13:53:10,855 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 13:53:10,862 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 13:53:10,862 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 13:53:10,862 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 13:53:10,863 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 13:53:10,863 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 13:53:10,866 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 13:53:10,867 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 13:53:10,867 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 13:53:10,867 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 13:53:10,867 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 13:53:10,868 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 13:53:10,868 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 13:53:10,868 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 13:53:10,868 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 13:53:10,868 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 13:53:10,868 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 13:53:12,070 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 13:53:12,070 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 13:53:12,071 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 13:55:58,136 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 13:55:58,136 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 13:55:58,136 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 13:55:58,136 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 13:55:58,136 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 13:55:58,136 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 13:55:58,136 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 13:55:58,136 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 13:55:58,136 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 13:55:58,136 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 13:55:58,136 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 13:55:58,138 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 13:55:58,138 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 13:55:58,138 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 13:55:58,138 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 13:55:58,138 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 13:55:58,138 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 13:55:58,138 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 13:55:58,139 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 13:55:58,139 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 13:55:58,139 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 13:55:58,139 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 13:55:58,139 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 13:55:58,140 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 13:55:58,140 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 13:55:58,140 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 13:55:58,140 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 13:55:58,140 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 13:55:58,143 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:06:42,929 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:06:42,933 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:06:42,933 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:06:42,933 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:06:43,046 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:06:43,052 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:06:43,053 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:06:43,054 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:06:43,055 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:06:43,056 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:06:43,057 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:06:43,058 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:06:43,059 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:06:43,063 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:06:43,064 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:06:43,065 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:06:43,065 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:06:43,067 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:06:43,067 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:06:43,067 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:06:43,069 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:06:43,072 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:06:43,072 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:06:43,076 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:06:43,077 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:06:43,151 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:06:43,151 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:06:43,212 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:06:43,213 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:06:43,214 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:06:43,218 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:06:43,223 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:06:43,224 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:06:43,229 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:06:43,231 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:06:43,231 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:06:43,266 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:06:43,367 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:06:43,594 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:06:43,612 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:06:43,612 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:06:43,612 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:06:43,613 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:06:43,650 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:06:43,653 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:06:43,654 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:06:43,662 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:06:43,662 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:06:43,670 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:06:43,686 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:06:43,692 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:06:43,695 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:06:43,697 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:06:43,699 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:06:43,701 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:06:43,703 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:06:43,704 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:06:43,706 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:06:43,707 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:06:43,707 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:06:43,708 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:06:43,708 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:06:43,709 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:06:43,709 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:06:43,710 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:06:43,710 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:06:43,711 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:06:43,712 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:06:43,713 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:06:43,714 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:06:43,715 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:06:43,716 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:06:43,717 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:06:43,718 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:06:43,719 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:06:43,720 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:06:43,721 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:06:43,722 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:06:43,723 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:06:43,724 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:06:43,725 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:06:43,725 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:06:43,726 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:06:43,727 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:06:43,730 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:06:43,731 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:06:43,731 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:06:43,732 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:06:43,733 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:06:43,734 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:06:43,755 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:06:43,757 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:06:43,757 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:06:43,760 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:06:43,761 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:06:43,761 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:06:44,063 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:06:44,063 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:06:44,063 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:06:44,156 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:06:44,156 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:06:44,157 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:06:44,242 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:06:44,242 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:06:44,243 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:06:44,307 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:06:44,307 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:06:44,307 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:06:44,308 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:06:44,352 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:06:44,353 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:06:44,353 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:06:44,353 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:06:44,353 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:06:44,361 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:06:44,361 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:06:44,361 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:06:44,361 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:06:44,362 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:06:44,362 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:06:44,362 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:06:44,362 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:06:44,362 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:06:44,362 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:06:44,363 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:06:44,363 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:06:44,363 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:06:44,363 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:06:44,363 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:06:44,363 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:06:44,363 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:06:44,363 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:06:44,364 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:06:44,364 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:06:44,364 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:06:44,364 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:06:44,364 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:06:44,364 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:06:44,387 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:06:44,387 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:06:44,387 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:06:44,403 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:06:44,404 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:06:44,404 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:06:44,404 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:06:44,404 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:06:44,404 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:06:44,404 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:06:44,404 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:06:44,411 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:06:44,411 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:06:44,411 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:06:44,413 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:06:44,413 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:06:44,416 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:06:44,419 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:06:44,419 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:06:44,419 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:06:44,419 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:06:44,419 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:06:44,424 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:06:44,424 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:06:44,424 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:06:44,424 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:06:44,425 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:06:46,016 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:06:46,017 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:06:46,018 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:07:31,737 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:07:31,738 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:07:31,739 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:07:31,739 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:07:31,741 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:07:31,743 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:07:36,592 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:07:36,595 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:07:36,596 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:07:36,596 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:07:36,688 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:07:36,692 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:07:36,692 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:07:36,693 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:07:36,694 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:07:36,694 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:07:36,695 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:07:36,695 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:07:36,696 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:07:36,698 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:07:36,700 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:07:36,700 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:07:36,701 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:07:36,702 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:07:36,702 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:07:36,703 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:07:36,704 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:07:36,706 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:07:36,707 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:07:36,710 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:07:36,712 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:07:36,786 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:07:36,786 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:07:36,845 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:07:36,846 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:07:36,848 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:07:36,851 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:07:36,856 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:07:36,857 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:07:36,862 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:07:36,863 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:07:36,863 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:07:36,893 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:07:37,002 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:07:37,211 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:07:37,226 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:07:37,226 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:07:37,226 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:07:37,227 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:07:37,257 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:07:37,260 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:07:37,261 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:07:37,268 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:07:37,269 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:07:37,277 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:07:37,295 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:07:37,302 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:07:37,305 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:07:37,307 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:07:37,310 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:07:37,312 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:07:37,314 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:07:37,315 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:07:37,317 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:07:37,318 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:07:37,319 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:07:37,319 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:07:37,320 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:07:37,321 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:07:37,322 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:07:37,323 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:07:37,324 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:07:37,325 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:07:37,326 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:07:37,327 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:07:37,329 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:07:37,330 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:07:37,331 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:07:37,332 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:07:37,333 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:07:37,334 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:07:37,335 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:07:37,336 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:07:37,337 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:07:37,338 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:07:37,338 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:07:37,339 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:07:37,340 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:07:37,341 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:07:37,341 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:07:37,343 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:07:37,344 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:07:37,344 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:07:37,345 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:07:37,346 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:07:37,347 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:07:37,356 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:07:37,358 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:07:37,358 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:07:37,361 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:07:37,361 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:07:37,361 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:07:37,612 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:07:37,612 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:07:37,612 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:07:37,706 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:07:37,706 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:07:37,706 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:07:37,799 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:07:37,799 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:07:37,800 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:07:37,860 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:07:37,860 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:07:37,861 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:07:37,861 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:07:37,906 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:07:37,907 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:07:37,907 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:07:37,907 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:07:37,907 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:07:37,914 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:07:37,914 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:07:37,914 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:07:37,915 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:07:37,915 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:07:37,915 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:07:37,915 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:07:37,915 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:07:37,915 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:07:37,915 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:07:37,915 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:07:37,916 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:07:37,916 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:07:37,916 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:07:37,916 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:07:37,916 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:07:37,916 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:07:37,916 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:07:37,916 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:07:37,916 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:07:37,917 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:07:37,917 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:07:37,917 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:07:37,917 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:07:37,941 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:07:37,941 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:07:37,941 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:07:37,957 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:07:37,957 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:07:37,957 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:07:37,957 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:07:37,957 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:07:37,957 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:07:37,958 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:07:37,958 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:07:37,965 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:07:37,965 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:07:37,966 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:07:37,967 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:07:37,967 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:07:37,969 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:07:37,970 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:07:37,971 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:07:37,971 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:07:37,971 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:07:37,971 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:07:37,971 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:07:37,971 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:07:37,971 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:07:37,972 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:07:37,972 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:07:39,151 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:07:39,151 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:07:39,152 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:09:09,168 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:09:14,379 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:09:14,383 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:09:14,383 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:09:14,383 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:09:14,468 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:09:14,471 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:09:14,472 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:09:14,472 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:09:14,473 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:09:14,473 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:09:14,474 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:09:14,475 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:09:14,475 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:09:14,478 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:09:14,479 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:09:14,479 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:09:14,480 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:09:14,481 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:09:14,481 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:09:14,482 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:09:14,483 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:09:14,485 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:09:14,486 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:09:14,489 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:09:14,490 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:09:14,558 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:09:14,559 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:09:14,617 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:09:14,618 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:09:14,619 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:09:14,622 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:09:14,627 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:09:14,628 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:09:14,634 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:09:14,636 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:09:14,636 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:09:14,668 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:09:14,777 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:09:14,985 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:09:14,998 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:09:14,998 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:09:14,998 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:09:14,999 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:09:15,033 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:09:15,036 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:09:15,036 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:09:15,044 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:09:15,045 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:09:15,051 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:09:15,063 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:09:15,070 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:09:15,072 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:09:15,073 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:09:15,075 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:09:15,077 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:09:15,078 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:09:15,080 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:09:15,082 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:09:15,082 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:09:15,083 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:09:15,083 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:09:15,084 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:09:15,084 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:09:15,085 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:09:15,085 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:09:15,086 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:09:15,087 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:09:15,087 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:09:15,088 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:09:15,090 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:09:15,091 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:09:15,092 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:09:15,093 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:09:15,094 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:09:15,095 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:09:15,096 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:09:15,097 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:09:15,098 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:09:15,099 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:09:15,099 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:09:15,100 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:09:15,101 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:09:15,102 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:09:15,102 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:09:15,103 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:09:15,104 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:09:15,105 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:09:15,105 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:09:15,106 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:09:15,106 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:09:15,113 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:09:15,114 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:09:15,114 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:09:15,115 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:09:15,115 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:09:15,116 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:09:15,370 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:09:15,370 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:09:15,370 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:09:15,476 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:09:15,476 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:09:15,476 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:09:15,561 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:09:15,561 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:09:15,561 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:09:15,624 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:09:15,624 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:09:15,625 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:09:15,625 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:09:15,669 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:09:15,670 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:09:15,670 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:09:15,670 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:09:15,670 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:09:15,678 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:09:15,678 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:09:15,678 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:09:15,678 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:09:15,678 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:09:15,678 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:09:15,679 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:09:15,679 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:09:15,679 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:09:15,679 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:09:15,679 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:09:15,679 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:09:15,679 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:09:15,679 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:09:15,680 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:09:15,680 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:09:15,680 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:09:15,680 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:09:15,680 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:09:15,680 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:09:15,680 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:09:15,680 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:09:15,681 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:09:15,681 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:09:15,702 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:09:15,703 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:09:15,703 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:09:15,718 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:09:15,718 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:09:15,718 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:09:15,718 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:09:15,718 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:09:15,718 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:09:15,718 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:09:15,719 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:09:15,725 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:09:15,726 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:09:15,726 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:09:15,727 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:09:15,727 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:09:15,730 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:09:15,731 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:09:15,731 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:09:15,731 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:09:15,731 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:09:15,731 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:09:15,731 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:09:15,731 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:09:15,732 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:09:15,732 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:09:15,732 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:09:16,890 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:09:16,891 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:09:16,891 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:10:24,566 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:10:24,567 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:10:24,567 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:10:24,567 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:10:24,567 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:10:24,567 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:10:24,567 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:10:24,567 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:10:24,567 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:10:24,567 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:10:24,568 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:10:24,568 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:10:24,568 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:10:24,568 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:10:24,568 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:10:24,568 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:10:24,568 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:10:24,568 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:10:24,568 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:10:24,568 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:10:24,568 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:10:24,569 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:10:24,569 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:10:24,569 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:10:24,569 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:10:24,569 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:10:24,569 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:10:24,569 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:10:24,573 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:11:41,786 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:11:41,790 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:11:41,790 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:11:41,790 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:11:41,892 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:11:41,898 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:11:41,899 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:11:41,900 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:11:41,900 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:11:41,901 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:11:41,902 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:11:41,903 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:11:41,904 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:11:41,908 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:11:41,910 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:11:41,911 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:11:41,912 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:11:41,913 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:11:41,914 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:11:41,915 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:11:41,916 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:11:41,919 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:11:41,919 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:11:41,923 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:11:41,925 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:11:42,002 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:11:42,002 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:11:42,068 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:11:42,069 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:11:42,070 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:11:42,073 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:11:42,079 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:11:42,080 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:11:42,086 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:11:42,088 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:11:42,088 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:11:42,113 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:11:42,243 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:11:42,518 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:11:42,535 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:11:42,536 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:11:42,536 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:11:42,536 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:11:42,584 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:11:42,589 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:11:42,589 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:11:42,601 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:11:42,602 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:11:42,610 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:11:42,629 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:11:42,636 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:11:42,638 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:11:42,640 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:11:42,642 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:11:42,644 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:11:42,646 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:11:42,648 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:11:42,649 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:11:42,650 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:11:42,651 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:11:42,651 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:11:42,652 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:11:42,653 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:11:42,654 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:11:42,655 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:11:42,656 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:11:42,658 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:11:42,658 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:11:42,660 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:11:42,662 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:11:42,663 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:11:42,664 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:11:42,665 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:11:42,666 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:11:42,667 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:11:42,668 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:11:42,669 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:11:42,670 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:11:42,671 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:11:42,672 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:11:42,672 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:11:42,673 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:11:42,674 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:11:42,674 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:11:42,676 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:11:42,677 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:11:42,678 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:11:42,679 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:11:42,679 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:11:42,681 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:11:42,690 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:11:42,691 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:11:42,691 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:11:42,692 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:11:42,693 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:11:42,693 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:11:43,032 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:11:43,033 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:11:43,033 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:11:43,160 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:11:43,160 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:11:43,160 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:11:43,278 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:11:43,278 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:11:43,278 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:11:43,362 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:11:43,362 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:11:43,362 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:11:43,362 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:11:43,455 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:11:43,459 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:11:43,459 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:11:43,459 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:11:43,460 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:11:43,471 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:11:43,471 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:11:43,475 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:11:43,480 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:11:43,480 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:11:43,481 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:11:43,481 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:11:43,481 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:11:43,481 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:11:43,481 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:11:43,481 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:11:43,481 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:11:43,481 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:11:43,481 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:11:43,481 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:11:43,482 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:11:43,482 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:11:43,482 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:11:43,482 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:11:43,482 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:11:43,483 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:11:43,483 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:11:43,483 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:11:43,483 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:11:43,518 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:11:43,518 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:11:43,518 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:11:43,542 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:11:43,543 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:11:43,543 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:11:43,543 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:11:43,543 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:11:43,544 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:11:43,544 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:11:43,544 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:11:43,550 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:11:43,550 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:11:43,551 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:11:43,552 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:11:43,552 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:11:43,555 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:11:43,556 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:11:43,556 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:11:43,557 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:11:43,557 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:11:43,557 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:11:43,557 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:11:43,557 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:11:43,557 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:11:43,557 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:11:43,557 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:11:45,015 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:11:45,016 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:11:45,017 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:13:08,527 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:13:08,527 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:13:08,527 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:13:08,527 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:13:08,527 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:13:08,527 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:13:08,528 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:13:08,532 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:13:23,831 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:13:23,834 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:13:23,834 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:13:23,835 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:13:23,936 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:13:23,941 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:13:23,942 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:13:23,943 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:13:23,943 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:13:23,944 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:13:23,944 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:13:23,945 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:13:23,945 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:13:23,948 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:13:23,950 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:13:23,950 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:13:23,951 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:13:23,952 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:13:23,953 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:13:23,953 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:13:23,956 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:13:23,958 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:13:23,958 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:13:23,962 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:13:23,963 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:13:24,051 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:13:24,051 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:13:24,127 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:13:24,128 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:13:24,130 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:13:24,138 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:13:24,143 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:13:24,144 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:13:24,151 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:13:24,152 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:13:24,152 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:13:24,191 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:13:24,324 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:13:24,604 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:13:24,620 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:13:24,620 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:13:24,620 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:13:24,621 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:13:24,658 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:13:24,661 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:13:24,661 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:13:24,673 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:13:24,673 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:13:24,681 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:13:24,697 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:13:24,704 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:13:24,707 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:13:24,709 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:13:24,712 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:13:24,714 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:13:24,717 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:13:24,718 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:13:24,720 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:13:24,721 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:13:24,722 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:13:24,722 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:13:24,723 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:13:24,724 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:13:24,725 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:13:24,726 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:13:24,727 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:13:24,728 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:13:24,729 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:13:24,730 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:13:24,732 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:13:24,733 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:13:24,734 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:13:24,735 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:13:24,736 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:13:24,737 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:13:24,738 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:13:24,739 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:13:24,739 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:13:24,740 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:13:24,741 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:13:24,741 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:13:24,742 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:13:24,743 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:13:24,743 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:13:24,745 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:13:24,746 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:13:24,747 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:13:24,747 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:13:24,748 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:13:24,749 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:13:24,758 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:13:24,759 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:13:24,760 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:13:24,761 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:13:24,761 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:13:24,761 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:13:25,043 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:13:25,048 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:13:25,048 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:13:25,165 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:13:25,165 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:13:25,165 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:13:25,248 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:13:25,249 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:13:25,249 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:13:25,345 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:13:25,345 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:13:25,345 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:13:25,345 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:13:25,409 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:13:25,410 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:13:25,410 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:13:25,410 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:13:25,410 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:13:25,426 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:13:25,426 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:13:25,427 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:13:25,427 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:13:25,427 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:13:25,427 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:13:25,427 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:13:25,427 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:13:25,427 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:13:25,429 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:13:25,429 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:13:25,429 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:13:25,429 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:13:25,429 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:13:25,433 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:13:25,433 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:13:25,433 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:13:25,433 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:13:25,433 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:13:25,434 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:13:25,434 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:13:25,434 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:13:25,434 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:13:25,434 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:13:25,473 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:13:25,473 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:13:25,474 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:13:25,491 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:13:25,492 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:13:25,492 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:13:25,492 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:13:25,493 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:13:25,493 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:13:25,493 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:13:25,493 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:13:25,499 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:13:25,499 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:13:25,500 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:13:25,501 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:13:25,501 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:13:25,503 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:13:25,504 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:13:25,504 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:13:25,505 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:13:25,505 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:13:25,505 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:13:25,505 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:13:25,505 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:13:25,505 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:13:25,505 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:13:25,505 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:13:26,741 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:13:26,741 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:13:26,742 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:13:58,050 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:13:58,050 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:13:58,053 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:13:58,053 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:13:58,053 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:13:58,053 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:13:58,053 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:13:58,053 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:13:58,053 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:13:58,053 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:13:58,053 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:13:58,053 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:13:58,053 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:13:58,056 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:13:58,056 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:13:58,057 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:20:33,002 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:20:33,007 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:20:33,008 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:20:33,008 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:20:33,111 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:20:33,117 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:20:33,118 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:20:33,119 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:20:33,119 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:20:33,120 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:20:33,121 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:20:33,122 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:20:33,123 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:20:33,127 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:20:33,129 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:20:33,130 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:20:33,131 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:20:33,133 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:20:33,134 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:20:33,135 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:20:33,137 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:20:33,139 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:20:33,140 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:20:33,147 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:20:33,148 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:20:33,232 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:20:33,232 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:20:33,295 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:20:33,296 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:20:33,297 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:20:33,300 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:20:33,306 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:20:33,307 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:20:33,313 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:20:33,315 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:20:33,315 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:20:33,355 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:20:33,480 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:20:33,744 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:20:33,759 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:20:33,759 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:20:33,759 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:20:33,760 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:20:33,803 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:20:33,809 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:20:33,810 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:20:33,821 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:20:33,821 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:20:33,830 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:20:33,858 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:20:33,865 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:20:33,867 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:20:33,870 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:20:33,872 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:20:33,875 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:20:33,877 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:20:33,878 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:20:33,880 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:20:33,881 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:20:33,881 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:20:33,882 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:20:33,883 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:20:33,884 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:20:33,885 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:20:33,886 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:20:33,887 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:20:33,888 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:20:33,889 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:20:33,890 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:20:33,892 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:20:33,893 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:20:33,894 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:20:33,895 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:20:33,896 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:20:33,897 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:20:33,898 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:20:33,899 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:20:33,900 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:20:33,901 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:20:33,902 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:20:33,902 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:20:33,903 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:20:33,904 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:20:33,904 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:20:33,906 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:20:33,907 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:20:33,908 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:20:33,908 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:20:33,909 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:20:33,911 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:20:33,920 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:20:33,921 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:20:33,921 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:20:33,922 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:20:33,922 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:20:33,922 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:20:34,227 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:20:34,227 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:20:34,228 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:20:34,343 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:20:34,343 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:20:34,343 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:20:34,452 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:20:34,453 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:20:34,453 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:20:34,517 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:20:34,517 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:20:34,517 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:20:34,517 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:20:34,571 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:20:34,571 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:20:34,571 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:20:34,571 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:20:34,571 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:20:34,578 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:20:34,578 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:20:34,579 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:20:34,579 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:20:34,579 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:20:34,579 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:20:34,579 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:20:34,579 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:20:34,580 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:20:34,580 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:20:34,580 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:20:34,580 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:20:34,580 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:20:34,580 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:20:34,580 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:20:34,581 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:20:34,581 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:20:34,581 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:20:34,581 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:20:34,581 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:20:34,581 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:20:34,581 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:20:34,581 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:20:34,581 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:20:34,604 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:20:34,604 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:20:34,604 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:20:34,623 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:20:34,623 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:20:34,623 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:20:34,623 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:20:34,624 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:20:34,624 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:20:34,624 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:20:34,624 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:20:34,648 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:20:34,648 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:20:34,648 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:20:34,649 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:20:34,649 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:20:34,652 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:20:34,653 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:20:34,653 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:20:34,653 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:20:34,653 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:20:34,653 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:20:34,654 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:20:34,654 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:20:34,654 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:20:34,654 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:20:34,654 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:20:36,003 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:20:36,003 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:20:36,004 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:20:52,518 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:23:55,292 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:23:55,295 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:23:55,295 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:23:55,295 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:23:55,396 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:23:55,400 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:23:55,401 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:23:55,401 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:23:55,402 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:23:55,403 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:23:55,403 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:23:55,404 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:23:55,404 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:23:55,407 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:23:55,408 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:23:55,409 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:23:55,409 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:23:55,410 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:23:55,411 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:23:55,411 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:23:55,412 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:23:55,414 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:23:55,415 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:23:55,419 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:23:55,420 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:23:55,491 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:23:55,491 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:23:55,549 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:23:55,549 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:23:55,551 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:23:55,554 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:23:55,559 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:23:55,559 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:23:55,565 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:23:55,566 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:23:55,566 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:23:55,589 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:23:55,692 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:23:55,900 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:23:55,915 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:23:55,915 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:23:55,915 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:23:55,916 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:23:55,948 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:23:55,951 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:23:55,951 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:23:55,959 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:23:55,960 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:23:55,966 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:23:55,983 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:23:55,988 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:23:55,990 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:23:55,992 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:23:55,994 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:23:55,996 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:23:55,998 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:23:55,999 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:23:56,001 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:23:56,002 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:23:56,003 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:23:56,004 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:23:56,005 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:23:56,006 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:23:56,007 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:23:56,008 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:23:56,008 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:23:56,010 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:23:56,011 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:23:56,012 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:23:56,014 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:23:56,015 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:23:56,017 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:23:56,019 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:23:56,020 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:23:56,021 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:23:56,022 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:23:56,023 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:23:56,023 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:23:56,024 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:23:56,025 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:23:56,026 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:23:56,027 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:23:56,028 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:23:56,028 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:23:56,030 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:23:56,031 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:23:56,031 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:23:56,032 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:23:56,033 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:23:56,034 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:23:56,044 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:23:56,045 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:23:56,045 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:23:56,046 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:23:56,046 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:23:56,046 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:23:56,317 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:23:56,317 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:23:56,318 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:23:56,426 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:23:56,426 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:23:56,427 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:23:56,507 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:23:56,507 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:23:56,507 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:23:56,563 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:23:56,563 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:23:56,563 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:23:56,563 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:23:56,611 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:23:56,611 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:23:56,611 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:23:56,612 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:23:56,612 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:23:56,621 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:23:56,621 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:23:56,622 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:23:56,622 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:23:56,622 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:23:56,622 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:23:56,622 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:23:56,622 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:23:56,623 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:23:56,623 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:23:56,623 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:23:56,623 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:23:56,623 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:23:56,623 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:23:56,623 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:23:56,624 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:23:56,624 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:23:56,624 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:23:56,624 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:23:56,624 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:23:56,624 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:23:56,624 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:23:56,625 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:23:56,625 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:23:56,648 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:23:56,648 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:23:56,648 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:23:56,664 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:23:56,664 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:23:56,664 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:23:56,664 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:23:56,665 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:23:56,665 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:23:56,665 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:23:56,665 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:23:56,676 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:23:56,676 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:23:56,677 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:23:56,692 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:23:56,692 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:23:56,695 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:23:56,696 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:23:56,696 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:23:56,697 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:23:56,697 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:23:56,697 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:23:56,697 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:23:56,697 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:23:56,697 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:23:56,697 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:23:56,697 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:23:57,837 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:23:57,838 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:23:57,838 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:24:18,310 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:24:18,310 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:24:18,310 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:24:18,310 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:24:18,310 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:24:18,311 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:24:18,312 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:24:18,312 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:24:18,312 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:24:18,312 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:24:56,496 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:24:56,500 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:24:56,500 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:24:56,500 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:24:56,588 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:24:56,592 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:24:56,592 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:24:56,593 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:24:56,594 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:24:56,594 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:24:56,595 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:24:56,596 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:24:56,596 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:24:56,599 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:24:56,600 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:24:56,601 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:24:56,601 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:24:56,602 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:24:56,603 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:24:56,603 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:24:56,605 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:24:56,607 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:24:56,607 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:24:56,611 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:24:56,612 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:24:56,681 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:24:56,681 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:24:56,738 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:24:56,739 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:24:56,740 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:24:56,743 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:24:56,749 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:24:56,750 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:24:56,755 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:24:56,757 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:24:56,757 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:24:56,780 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:24:56,895 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:24:57,097 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:24:57,112 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:24:57,112 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:24:57,112 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:24:57,113 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:24:57,146 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:24:57,149 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:24:57,149 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:24:57,156 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:24:57,157 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:24:57,165 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:24:57,183 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:24:57,190 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:24:57,192 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:24:57,194 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:24:57,197 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:24:57,199 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:24:57,201 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:24:57,202 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:24:57,203 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:24:57,205 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:24:57,205 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:24:57,206 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:24:57,207 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:24:57,208 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:24:57,209 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:24:57,210 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:24:57,211 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:24:57,213 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:24:57,214 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:24:57,215 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:24:57,217 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:24:57,218 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:24:57,219 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:24:57,220 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:24:57,221 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:24:57,222 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:24:57,223 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:24:57,224 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:24:57,225 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:24:57,226 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:24:57,227 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:24:57,228 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:24:57,229 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:24:57,230 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:24:57,230 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:24:57,232 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:24:57,233 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:24:57,234 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:24:57,234 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:24:57,235 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:24:57,237 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:24:57,246 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:24:57,248 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:24:57,248 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:24:57,251 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:24:57,251 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:24:57,251 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:24:57,499 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:24:57,499 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:24:57,499 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:24:57,593 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:24:57,594 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:24:57,594 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:24:57,683 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:24:57,683 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:24:57,683 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:24:57,744 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:24:57,744 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:24:57,744 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:24:57,744 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:24:57,793 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:24:57,793 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:24:57,793 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:24:57,793 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:24:57,793 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:24:57,801 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:24:57,801 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:24:57,801 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:24:57,801 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:24:57,801 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:24:57,802 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:24:57,802 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:24:57,802 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:24:57,802 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:24:57,802 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:24:57,802 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:24:57,802 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:24:57,802 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:24:57,803 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:24:57,803 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:24:57,803 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:24:57,803 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:24:57,803 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:24:57,803 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:24:57,804 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:24:57,804 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:24:57,804 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:24:57,804 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:24:57,804 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:24:57,833 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:24:57,833 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:24:57,833 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:24:57,847 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:24:57,847 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:24:57,847 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:24:57,847 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:24:57,847 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:24:57,847 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:24:57,847 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:24:57,847 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:24:57,854 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:24:57,854 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:24:57,854 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:24:57,855 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:24:57,855 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:24:57,858 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:24:57,859 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:24:57,859 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:24:57,859 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:24:57,860 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:24:57,860 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:24:57,860 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:24:57,860 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:24:57,860 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:24:57,860 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:24:57,860 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:24:59,111 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:24:59,111 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:24:59,112 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:33:13,618 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:33:13,621 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:33:13,621 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:33:13,622 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:33:13,730 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:33:13,734 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:33:13,735 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:33:13,736 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:33:13,736 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:33:13,737 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:33:13,737 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:33:13,738 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:33:13,739 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:33:13,743 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:33:13,744 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:33:13,745 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:33:13,745 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:33:13,747 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:33:13,748 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:33:13,748 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:33:13,750 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:33:13,753 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:33:13,754 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:33:13,759 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:33:13,760 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:33:13,843 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:33:13,843 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:33:13,912 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:33:13,914 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:33:13,915 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:33:13,918 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:33:13,923 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:33:13,924 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:33:13,931 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:33:13,933 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:33:13,933 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:33:13,959 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:33:14,117 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:33:14,362 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:33:14,378 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:33:14,378 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:33:14,378 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:33:14,380 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:33:14,423 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:33:14,426 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:33:14,426 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:33:14,440 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:33:14,441 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:33:14,449 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:33:14,477 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:33:14,483 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:33:14,485 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:33:14,489 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:33:14,503 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:33:14,505 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:33:14,509 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:33:14,510 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:33:14,511 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:33:14,512 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:33:14,513 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:33:14,514 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:33:14,515 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:33:14,516 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:33:14,517 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:33:14,518 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:33:14,519 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:33:14,521 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:33:14,522 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:33:14,523 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:33:14,525 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:33:14,526 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:33:14,527 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:33:14,528 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:33:14,529 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:33:14,530 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:33:14,531 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:33:14,532 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:33:14,533 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:33:14,534 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:33:14,535 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:33:14,536 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:33:14,537 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:33:14,538 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:33:14,538 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:33:14,539 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:33:14,540 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:33:14,546 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:33:14,547 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:33:14,548 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:33:14,549 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:33:14,561 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:33:14,562 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:33:14,562 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:33:14,563 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:33:14,564 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:33:14,564 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:33:14,897 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:33:14,897 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:33:14,901 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:33:15,011 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:33:15,011 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:33:15,011 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:33:15,116 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:33:15,116 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:33:15,116 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:33:15,201 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:33:15,201 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:33:15,201 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:33:15,202 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:33:15,289 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:33:15,290 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:33:15,290 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:33:15,290 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:33:15,290 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:33:15,297 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:33:15,297 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:33:15,298 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:33:15,298 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:33:15,298 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:33:15,298 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:33:15,298 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:33:15,299 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:33:15,299 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:33:15,299 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:33:15,299 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:33:15,299 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:33:15,299 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:33:15,299 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:33:15,299 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:33:15,300 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:33:15,300 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:33:15,300 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:33:15,300 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:33:15,300 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:33:15,300 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:33:15,300 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:33:15,301 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:33:15,301 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:33:15,323 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:33:15,324 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:33:15,324 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:33:15,346 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:33:15,346 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:33:15,346 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:33:15,346 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:33:15,346 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:33:15,346 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:33:15,347 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:33:15,347 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:33:15,353 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:33:15,354 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:33:15,354 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:33:15,355 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:33:15,355 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:33:15,358 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:33:15,359 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:33:15,359 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:33:15,359 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:33:15,359 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:33:15,359 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:33:15,360 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:33:15,360 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:33:15,360 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:33:15,360 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:33:15,360 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:33:16,940 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:33:16,940 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:33:16,941 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:33:19,684 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:33:19,684 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:33:19,684 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:33:19,684 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:33:19,684 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:33:19,685 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:33:19,686 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:33:19,686 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:33:19,686 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:33:19,686 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:33:19,687 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:33:23,001 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:33:23,004 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:33:23,004 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:33:23,004 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:33:23,004 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:33:23,004 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:33:23,004 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:33:23,004 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:33:23,006 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:33:27,588 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:33:27,592 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:33:27,592 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:33:27,592 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:33:27,682 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:33:27,687 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:33:27,688 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:33:27,688 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:33:27,689 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:33:27,689 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:33:27,690 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:33:27,691 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:33:27,691 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:33:27,694 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:33:27,695 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:33:27,696 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:33:27,696 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:33:27,697 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:33:27,698 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:33:27,698 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:33:27,700 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:33:27,701 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:33:27,702 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:33:27,705 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:33:27,707 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:33:27,776 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:33:27,776 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:33:27,833 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:33:27,834 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:33:27,836 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:33:27,839 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:33:27,845 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:33:27,846 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:33:27,852 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:33:27,853 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:33:27,853 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:33:27,885 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:33:27,990 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:33:28,185 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:33:28,200 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:33:28,200 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:33:28,200 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:33:28,201 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:33:28,236 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:33:28,239 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:33:28,239 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:33:28,247 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:33:28,247 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:33:28,255 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:33:28,269 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:33:28,275 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:33:28,276 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:33:28,278 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:33:28,280 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:33:28,283 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:33:28,284 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:33:28,286 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:33:28,287 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:33:28,288 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:33:28,289 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:33:28,289 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:33:28,289 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:33:28,290 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:33:28,291 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:33:28,291 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:33:28,292 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:33:28,292 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:33:28,293 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:33:28,294 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:33:28,295 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:33:28,296 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:33:28,297 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:33:28,298 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:33:28,299 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:33:28,300 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:33:28,301 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:33:28,302 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:33:28,303 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:33:28,304 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:33:28,305 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:33:28,306 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:33:28,307 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:33:28,307 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:33:28,308 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:33:28,309 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:33:28,310 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:33:28,310 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:33:28,311 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:33:28,311 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:33:28,312 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:33:28,319 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:33:28,321 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:33:28,321 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:33:28,324 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:33:28,325 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:33:28,325 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:33:28,595 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:33:28,595 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:33:28,596 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:33:28,703 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:33:28,703 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:33:28,704 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:33:28,785 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:33:28,785 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:33:28,785 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:33:28,842 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:33:28,842 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:33:28,842 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:33:28,842 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:33:28,892 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:33:28,892 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:33:28,892 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:33:28,892 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:33:28,892 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:33:28,899 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:33:28,899 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:33:28,899 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:33:28,899 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:33:28,899 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:33:28,900 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:33:28,900 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:33:28,900 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:33:28,900 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:33:28,900 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:33:28,900 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:33:28,900 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:33:28,900 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:33:28,901 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:33:28,901 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:33:28,901 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:33:28,901 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:33:28,901 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:33:28,901 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:33:28,901 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:33:28,901 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:33:28,901 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:33:28,902 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:33:28,902 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:33:28,927 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:33:28,927 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:33:28,927 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:33:28,943 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:33:28,943 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:33:28,943 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:33:28,943 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:33:28,944 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:33:28,944 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:33:28,944 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:33:28,944 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:33:28,951 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:33:28,951 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:33:28,951 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:33:28,952 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:33:28,952 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:33:28,955 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:33:28,956 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:33:28,956 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:33:28,957 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:33:28,957 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:33:28,957 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:33:28,957 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:33:28,957 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:33:28,957 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:33:28,957 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:33:28,957 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:33:30,088 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:33:30,089 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:33:30,089 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:35:26,875 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:38:06,145 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:38:06,149 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:38:06,149 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:38:06,149 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:38:06,238 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:38:06,242 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:38:06,243 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:38:06,243 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:38:06,244 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:38:06,244 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:38:06,245 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:38:06,246 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:38:06,246 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:38:06,249 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:38:06,250 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:38:06,251 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:38:06,251 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:38:06,252 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:38:06,253 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:38:06,253 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:38:06,255 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:38:06,257 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:38:06,257 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:38:06,261 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:38:06,262 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:38:06,333 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:38:06,333 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:38:06,390 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:38:06,391 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:38:06,393 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:38:06,396 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:38:06,402 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:38:06,402 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:38:06,409 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:38:06,411 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:38:06,411 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:38:06,444 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:38:06,547 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:38:06,750 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:38:06,766 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:38:06,766 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:38:06,766 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:38:06,767 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:38:06,800 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:38:06,803 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:38:06,803 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:38:06,811 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:38:06,811 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:38:06,819 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:38:06,836 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:38:06,843 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:38:06,846 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:38:06,848 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:38:06,850 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:38:06,851 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:38:06,853 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:38:06,854 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:38:06,855 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:38:06,856 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:38:06,857 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:38:06,857 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:38:06,858 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:38:06,858 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:38:06,859 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:38:06,859 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:38:06,860 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:38:06,861 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:38:06,861 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:38:06,862 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:38:06,864 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:38:06,865 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:38:06,866 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:38:06,867 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:38:06,868 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:38:06,869 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:38:06,870 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:38:06,871 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:38:06,871 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:38:06,872 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:38:06,873 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:38:06,874 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:38:06,875 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:38:06,876 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:38:06,876 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:38:06,877 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:38:06,878 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:38:06,879 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:38:06,879 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:38:06,879 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:38:06,880 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:38:06,887 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:38:06,888 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:38:06,889 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:38:06,889 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:38:06,890 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:38:06,890 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:38:07,162 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:38:07,162 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:38:07,162 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:38:07,279 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:38:07,279 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:38:07,280 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:38:07,369 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:38:07,369 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:38:07,370 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:38:07,429 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:38:07,430 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:38:07,430 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:38:07,430 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:38:07,477 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:38:07,477 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:38:07,478 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:38:07,478 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:38:07,478 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:38:07,485 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:38:07,485 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:38:07,485 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:38:07,485 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:38:07,485 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:38:07,486 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:38:07,486 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:38:07,486 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:38:07,486 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:38:07,486 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:38:07,487 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:38:07,487 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:38:07,487 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:38:07,487 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:38:07,487 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:38:07,487 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:38:07,488 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:38:07,488 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:38:07,488 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:38:07,488 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:38:07,488 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:38:07,488 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:38:07,488 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:38:07,488 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:38:07,516 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:38:07,516 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:38:07,516 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:38:07,531 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:38:07,531 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:38:07,531 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:38:07,531 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:38:07,531 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:38:07,531 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:38:07,531 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:38:07,532 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:38:07,538 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:38:07,538 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:38:07,538 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:38:07,540 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:38:07,540 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:38:07,543 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:38:07,545 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:38:07,545 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:38:07,545 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:38:07,545 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:38:07,545 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:38:07,545 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:38:07,545 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:38:07,546 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:38:07,546 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:38:07,546 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:38:08,757 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:38:08,758 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:38:08,759 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:39:51,173 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:39:51,176 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:39:51,177 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:39:51,177 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:39:51,262 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:39:51,266 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:39:51,267 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:39:51,268 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:39:51,268 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:39:51,269 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:39:51,269 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:39:51,270 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:39:51,270 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:39:51,273 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:39:51,274 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:39:51,275 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:39:51,275 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:39:51,276 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:39:51,277 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:39:51,277 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:39:51,279 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:39:51,280 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:39:51,281 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:39:51,284 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:39:51,286 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:39:51,357 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:39:51,357 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:39:51,416 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:39:51,417 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:39:51,418 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:39:51,422 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:39:51,426 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:39:51,427 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:39:51,432 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:39:51,433 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:39:51,433 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:39:51,455 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:39:51,563 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:39:51,774 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:39:51,785 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:39:51,785 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:39:51,785 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:39:51,785 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:39:51,816 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:39:51,819 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:39:51,819 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:39:51,827 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:39:51,828 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:39:51,834 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:39:51,848 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:39:51,855 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:39:51,857 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:39:51,860 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:39:51,862 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:39:51,864 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:39:51,866 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:39:51,867 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:39:51,869 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:39:51,870 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:39:51,871 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:39:51,872 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:39:51,872 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:39:51,873 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:39:51,874 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:39:51,875 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:39:51,876 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:39:51,878 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:39:51,879 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:39:51,880 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:39:51,882 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:39:51,882 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:39:51,884 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:39:51,885 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:39:51,886 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:39:51,887 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:39:51,888 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:39:51,889 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:39:51,890 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:39:51,891 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:39:51,892 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:39:51,893 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:39:51,894 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:39:51,895 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:39:51,895 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:39:51,897 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:39:51,898 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:39:51,899 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:39:51,899 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:39:51,900 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:39:51,902 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:39:51,911 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:39:51,912 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:39:51,912 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:39:51,913 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:39:51,913 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:39:51,914 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:39:52,162 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:39:52,162 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:39:52,162 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:39:52,266 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:39:52,266 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:39:52,266 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:39:52,349 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:39:52,349 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:39:52,350 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:39:52,411 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:39:52,411 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:39:52,411 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:39:52,411 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:39:52,462 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:39:52,462 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:39:52,462 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:39:52,462 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:39:52,462 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:39:52,469 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:39:52,469 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:39:52,470 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:39:52,470 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:39:52,470 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:39:52,470 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:39:52,470 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:39:52,471 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:39:52,471 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:39:52,471 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:39:52,471 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:39:52,471 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:39:52,471 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:39:52,471 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:39:52,471 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:39:52,472 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:39:52,472 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:39:52,472 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:39:52,472 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:39:52,472 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:39:52,472 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:39:52,472 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:39:52,473 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:39:52,473 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:39:52,495 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:39:52,495 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:39:52,495 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:39:52,511 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:39:52,511 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:39:52,511 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:39:52,511 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:39:52,512 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:39:52,512 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:39:52,512 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:39:52,512 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:39:52,519 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:39:52,519 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:39:52,519 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:39:52,520 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:39:52,521 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:39:52,523 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:39:52,524 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:39:52,524 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:39:52,525 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:39:52,525 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:39:52,525 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:39:52,525 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:39:52,525 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:39:52,525 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:39:52,525 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:39:52,526 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:39:53,663 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:39:53,663 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:39:53,664 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:44:24,403 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:44:24,403 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:44:24,403 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:44:24,403 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:44:24,403 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:44:24,403 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:44:24,403 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:44:24,403 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:44:24,403 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:44:24,403 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:44:24,404 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:44:24,404 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:44:24,404 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:44:24,404 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:44:24,404 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:44:24,404 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:44:24,404 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:44:24,404 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:44:24,405 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:44:24,405 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:44:24,405 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:44:24,405 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:44:24,405 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:44:24,405 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:44:24,405 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:44:24,405 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:44:24,405 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:44:24,405 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:44:24,409 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:44:29,162 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:44:29,165 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:44:29,165 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:44:29,165 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:44:29,255 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:44:29,260 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:44:29,261 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:44:29,262 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:44:29,262 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:44:29,263 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:44:29,264 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:44:29,264 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:44:29,265 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:44:29,268 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:44:29,269 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:44:29,270 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:44:29,270 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:44:29,271 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:44:29,272 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:44:29,272 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:44:29,273 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:44:29,275 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:44:29,276 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:44:29,280 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:44:29,281 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:44:29,352 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:44:29,352 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:44:29,409 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:44:29,410 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:44:29,411 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:44:29,415 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:44:29,420 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:44:29,421 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:44:29,426 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:44:29,427 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:44:29,427 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:44:29,450 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:44:29,551 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:44:29,749 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:44:29,764 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:44:29,764 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:44:29,765 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:44:29,765 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:44:29,798 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:44:29,801 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:44:29,801 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:44:29,809 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:44:29,809 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:44:29,818 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:44:29,832 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:44:29,838 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:44:29,840 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:44:29,842 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:44:29,844 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:44:29,845 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:44:29,847 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:44:29,848 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:44:29,849 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:44:29,849 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:44:29,850 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:44:29,850 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:44:29,851 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:44:29,851 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:44:29,852 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:44:29,852 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:44:29,853 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:44:29,854 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:44:29,855 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:44:29,856 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:44:29,858 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:44:29,859 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:44:29,860 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:44:29,861 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:44:29,862 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:44:29,863 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:44:29,864 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:44:29,865 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:44:29,865 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:44:29,866 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:44:29,867 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:44:29,868 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:44:29,869 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:44:29,869 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:44:29,870 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:44:29,871 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:44:29,872 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:44:29,873 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:44:29,873 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:44:29,874 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:44:29,875 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:44:29,885 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:44:29,886 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:44:29,886 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:44:29,887 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:44:29,887 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:44:29,887 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:44:30,150 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:44:30,150 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:44:30,150 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:44:30,259 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:44:30,259 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:44:30,259 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:44:30,347 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:44:30,347 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:44:30,347 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:44:30,408 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:44:30,408 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:44:30,408 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:44:30,408 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:44:30,454 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:44:30,454 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:44:30,454 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:44:30,454 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:44:30,455 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:44:30,462 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:44:30,462 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:44:30,463 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:44:30,463 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:44:30,463 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:44:30,463 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:44:30,463 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:44:30,464 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:44:30,464 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:44:30,464 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:44:30,464 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:44:30,464 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:44:30,464 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:44:30,464 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:44:30,464 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:44:30,465 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:44:30,465 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:44:30,465 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:44:30,465 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:44:30,465 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:44:30,465 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:44:30,465 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:44:30,465 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:44:30,466 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:44:30,494 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:44:30,495 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:44:30,495 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:44:30,511 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:44:30,511 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:44:30,511 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:44:30,511 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:44:30,511 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:44:30,512 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:44:30,512 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:44:30,512 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:44:30,519 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:44:30,519 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:44:30,519 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:44:30,520 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:44:30,521 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:44:30,523 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:44:30,525 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:44:30,525 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:44:30,525 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:44:30,525 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:44:30,525 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:44:30,526 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:44:30,526 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:44:30,526 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:44:30,526 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:44:30,526 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:44:31,657 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:44:31,658 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:44:31,659 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:48:45,755 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:48:45,755 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:48:45,755 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:48:45,755 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:48:45,755 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:48:45,756 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:48:45,756 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:48:45,756 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:48:45,756 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:48:45,756 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:48:45,756 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:48:45,756 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:48:45,756 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:48:45,756 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:48:45,756 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:48:45,756 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:48:45,757 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:48:45,759 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:50:09,333 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:50:09,336 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:50:09,336 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:50:09,336 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:50:09,420 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:50:09,424 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:50:09,425 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:50:09,426 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:50:09,426 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:50:09,427 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:50:09,427 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:50:09,428 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:50:09,428 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:50:09,431 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:50:09,432 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:50:09,433 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:50:09,433 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:50:09,434 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:50:09,435 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:50:09,435 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:50:09,437 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:50:09,439 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:50:09,439 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:50:09,443 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:50:09,444 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:50:09,513 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:50:09,514 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:50:09,572 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:50:09,573 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:50:09,574 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:50:09,578 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:50:09,583 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:50:09,584 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:50:09,588 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:50:09,590 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:50:09,590 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:50:09,619 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:50:09,715 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:50:09,911 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:50:09,926 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:50:09,926 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:50:09,926 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:50:09,927 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:50:09,961 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:50:09,964 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:50:09,965 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:50:09,973 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:50:09,973 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:50:09,980 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:50:09,996 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:50:10,003 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:50:10,004 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:50:10,006 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:50:10,008 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:50:10,009 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:50:10,011 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:50:10,012 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:50:10,014 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:50:10,014 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:50:10,015 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:50:10,015 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:50:10,016 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:50:10,016 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:50:10,017 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:50:10,017 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:50:10,018 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:50:10,019 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:50:10,019 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:50:10,020 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:50:10,022 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:50:10,023 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:50:10,024 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:50:10,025 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:50:10,026 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:50:10,027 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:50:10,028 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:50:10,029 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:50:10,029 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:50:10,030 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:50:10,031 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:50:10,032 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:50:10,033 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:50:10,034 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:50:10,034 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:50:10,035 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:50:10,036 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:50:10,037 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:50:10,037 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:50:10,038 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:50:10,039 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:50:10,045 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:50:10,047 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:50:10,047 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:50:10,048 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:50:10,048 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:50:10,048 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:50:10,293 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:50:10,293 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:50:10,294 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:50:10,404 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:50:10,404 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:50:10,404 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:50:10,491 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:50:10,491 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:50:10,491 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:50:10,549 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:50:10,549 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:50:10,549 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:50:10,549 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:50:10,595 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:50:10,596 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:50:10,596 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:50:10,596 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:50:10,596 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:50:10,603 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:50:10,603 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:50:10,603 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:50:10,603 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:50:10,604 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:50:10,604 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:50:10,604 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:50:10,604 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:50:10,604 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:50:10,604 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:50:10,605 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:50:10,605 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:50:10,605 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:50:10,605 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:50:10,605 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:50:10,605 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:50:10,605 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:50:10,605 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:50:10,606 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:50:10,606 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:50:10,606 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:50:10,606 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:50:10,606 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:50:10,606 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:50:10,634 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:50:10,634 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:50:10,634 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:50:10,650 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:50:10,651 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:50:10,651 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:50:10,651 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:50:10,651 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:50:10,651 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:50:10,651 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:50:10,651 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:50:10,659 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:50:10,659 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:50:10,659 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:50:10,661 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:50:10,661 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:50:10,663 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:50:10,665 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:50:10,665 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:50:10,665 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:50:10,665 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:50:10,665 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:50:10,665 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:50:10,665 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:50:10,666 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:50:10,666 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:50:10,666 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:50:11,847 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:50:11,848 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:50:11,848 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:50:51,547 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:50:51,548 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:50:58,503 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:50:58,508 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:50:58,508 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:50:58,508 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:50:58,597 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:50:58,602 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:50:58,602 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:50:58,603 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:50:58,604 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:50:58,604 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:50:58,605 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:50:58,606 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:50:58,606 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:50:58,609 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:50:58,610 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:50:58,611 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:50:58,611 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:50:58,612 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:50:58,613 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:50:58,613 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:50:58,615 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:50:58,617 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:50:58,617 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:50:58,621 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:50:58,622 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:50:58,693 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:50:58,693 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:50:58,750 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:50:58,751 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:50:58,752 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:50:58,756 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:50:58,760 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:50:58,761 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:50:58,766 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:50:58,767 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:50:58,768 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:50:58,799 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:50:58,901 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 14:50:59,130 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 14:50:59,141 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 14:50:59,141 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 14:50:59,141 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 14:50:59,142 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 14:50:59,172 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 14:50:59,175 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 14:50:59,175 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 14:50:59,184 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 14:50:59,184 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:50:59,190 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 14:50:59,203 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 14:50:59,209 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 14:50:59,211 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 14:50:59,213 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 14:50:59,215 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 14:50:59,217 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 14:50:59,219 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 14:50:59,220 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 14:50:59,221 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 14:50:59,222 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 14:50:59,223 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 14:50:59,224 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 14:50:59,225 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 14:50:59,226 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 14:50:59,227 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 14:50:59,228 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 14:50:59,229 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 14:50:59,230 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 14:50:59,231 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 14:50:59,232 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 14:50:59,234 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 14:50:59,235 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 14:50:59,237 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 14:50:59,238 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 14:50:59,239 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 14:50:59,240 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 14:50:59,241 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 14:50:59,242 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 14:50:59,243 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 14:50:59,243 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 14:50:59,244 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 14:50:59,245 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 14:50:59,246 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 14:50:59,248 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 14:50:59,248 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 14:50:59,249 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 14:50:59,251 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 14:50:59,251 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 14:50:59,252 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 14:50:59,253 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 14:50:59,255 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 14:50:59,264 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 14:50:59,266 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 14:50:59,266 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 14:50:59,267 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:50:59,267 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 14:50:59,267 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 14:50:59,483 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 14:50:59,483 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 14:50:59,483 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 14:50:59,574 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 14:50:59,574 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 14:50:59,575 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 14:50:59,659 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 14:50:59,659 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 14:50:59,659 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 14:50:59,720 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 14:50:59,720 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 14:50:59,720 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 14:50:59,720 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 14:50:59,767 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:50:59,767 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:50:59,767 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 14:50:59,768 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 14:50:59,768 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 14:50:59,775 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 14:50:59,775 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:50:59,776 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:50:59,776 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 14:50:59,776 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:50:59,776 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:50:59,776 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:50:59,776 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:50:59,776 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 14:50:59,777 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 14:50:59,777 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 14:50:59,777 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 14:50:59,777 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 14:50:59,777 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 14:50:59,777 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 14:50:59,777 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 14:50:59,777 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 14:50:59,778 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 14:50:59,778 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 14:50:59,778 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 14:50:59,778 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 14:50:59,778 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 14:50:59,778 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 14:50:59,778 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 14:50:59,802 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 14:50:59,802 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 14:50:59,803 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 14:50:59,818 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 14:50:59,819 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 14:50:59,819 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 14:50:59,819 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:50:59,819 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:50:59,819 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 14:50:59,819 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 14:50:59,819 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 14:50:59,827 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 14:50:59,827 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 14:50:59,827 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 14:50:59,828 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 14:50:59,828 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 14:50:59,836 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 14:50:59,837 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 14:50:59,837 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 14:50:59,838 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 14:50:59,838 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 14:50:59,838 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 14:50:59,838 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 14:50:59,838 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 14:50:59,838 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 14:50:59,839 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 14:50:59,839 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 14:51:01,083 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 14:51:01,083 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 14:51:01,084 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 14:57:19,964 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 14:57:19,964 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 14:57:19,964 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 14:57:19,964 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 14:57:19,964 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 14:57:19,964 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 14:57:19,964 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 14:57:19,964 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:57:19,964 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 14:57:19,964 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 14:57:19,965 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 14:57:19,967 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 14:59:59,603 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 14:59:59,606 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 14:59:59,606 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 14:59:59,606 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 14:59:59,691 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 14:59:59,695 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 14:59:59,696 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 14:59:59,696 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 14:59:59,697 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 14:59:59,697 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 14:59:59,698 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 14:59:59,699 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 14:59:59,699 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 14:59:59,702 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 14:59:59,703 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 14:59:59,703 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 14:59:59,704 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 14:59:59,705 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 14:59:59,705 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 14:59:59,706 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 14:59:59,707 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 14:59:59,709 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 14:59:59,709 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 14:59:59,713 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 14:59:59,714 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 14:59:59,783 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 14:59:59,783 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 14:59:59,840 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 14:59:59,841 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 14:59:59,842 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 14:59:59,846 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 14:59:59,851 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 14:59:59,852 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 14:59:59,858 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 14:59:59,859 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 14:59:59,860 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 14:59:59,891 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 14:59:59,992 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 15:00:00,226 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 15:00:00,242 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 15:00:00,242 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 15:00:00,242 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 15:00:00,243 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 15:00:00,275 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 15:00:00,279 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 15:00:00,279 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 15:00:00,287 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 15:00:00,287 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 15:00:00,295 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 15:00:00,312 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 15:00:00,319 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 15:00:00,322 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 15:00:00,324 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 15:00:00,327 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 15:00:00,329 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 15:00:00,331 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 15:00:00,332 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 15:00:00,333 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 15:00:00,335 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 15:00:00,336 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 15:00:00,336 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 15:00:00,337 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 15:00:00,338 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 15:00:00,339 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 15:00:00,340 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 15:00:00,341 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 15:00:00,343 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 15:00:00,343 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 15:00:00,344 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 15:00:00,346 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 15:00:00,346 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 15:00:00,348 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 15:00:00,349 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 15:00:00,350 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 15:00:00,351 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 15:00:00,352 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 15:00:00,353 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 15:00:00,353 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 15:00:00,354 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 15:00:00,355 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 15:00:00,356 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 15:00:00,357 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 15:00:00,358 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 15:00:00,358 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 15:00:00,360 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 15:00:00,361 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 15:00:00,362 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 15:00:00,362 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 15:00:00,363 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 15:00:00,364 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 15:00:00,373 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 15:00:00,374 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 15:00:00,374 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 15:00:00,375 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 15:00:00,376 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 15:00:00,376 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 15:00:00,648 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 15:00:00,648 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 15:00:00,648 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 15:00:00,755 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 15:00:00,755 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 15:00:00,755 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 15:00:00,846 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 15:00:00,846 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 15:00:00,846 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 15:00:00,911 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 15:00:00,911 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 15:00:00,911 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 15:00:00,911 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 15:00:00,962 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 15:00:00,962 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 15:00:00,962 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 15:00:00,962 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 15:00:00,962 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 15:00:00,969 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 15:00:00,970 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 15:00:00,970 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 15:00:00,970 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 15:00:00,970 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 15:00:00,970 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 15:00:00,970 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 15:00:00,972 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 15:00:00,972 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 15:00:00,972 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 15:00:00,972 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 15:00:00,972 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 15:00:00,972 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 15:00:00,972 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 15:00:00,973 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 15:00:00,973 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 15:00:00,973 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 15:00:00,973 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 15:00:00,973 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 15:00:00,974 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 15:00:00,974 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 15:00:00,974 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 15:00:00,974 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 15:00:00,974 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 15:00:00,998 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 15:00:00,998 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 15:00:00,998 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 15:00:01,013 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 15:00:01,014 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 15:00:01,014 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 15:00:01,014 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 15:00:01,014 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 15:00:01,014 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 15:00:01,014 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 15:00:01,014 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 15:00:01,021 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 15:00:01,027 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 15:00:01,027 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 15:00:01,028 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 15:00:01,028 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 15:00:01,031 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 15:00:01,032 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 15:00:01,032 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 15:00:01,033 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 15:00:01,033 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 15:00:01,033 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 15:00:01,033 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 15:00:01,033 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 15:00:01,033 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 15:00:01,034 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 15:00:01,034 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 15:00:02,209 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 15:00:02,209 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 15:00:02,210 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 15:00:48,106 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 15:00:48,106 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 15:00:48,107 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 15:00:48,108 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 15:00:48,108 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 15:00:48,109 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 15:00:48,109 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 15:00:48,109 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 15:00:48,109 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 15:00:48,109 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 15:00:48,109 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 15:01:09,250 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 15:01:09,254 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 15:01:09,254 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 15:01:09,254 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 15:01:09,345 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 15:01:09,350 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 15:01:09,350 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 15:01:09,351 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 15:01:09,352 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 15:01:09,352 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 15:01:09,353 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 15:01:09,353 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 15:01:09,354 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 15:01:09,357 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 15:01:09,358 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 15:01:09,358 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 15:01:09,359 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 15:01:09,360 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 15:01:09,360 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 15:01:09,361 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 15:01:09,362 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 15:01:09,364 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 15:01:09,364 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 15:01:09,368 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 15:01:09,369 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 15:01:09,439 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 15:01:09,439 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 15:01:09,498 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 15:01:09,499 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 15:01:09,500 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 15:01:09,503 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 15:01:09,508 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 15:01:09,509 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 15:01:09,515 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 15:01:09,517 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 15:01:09,517 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 15:01:09,538 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 15:01:09,649 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 15:01:09,870 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 15:01:09,881 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 15:01:09,881 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 15:01:09,881 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 15:01:09,882 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 15:01:09,913 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 15:01:09,916 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 15:01:09,916 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 15:01:09,925 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 15:01:09,925 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 15:01:09,931 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 15:01:09,943 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 15:01:09,949 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 15:01:09,950 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 15:01:09,952 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 15:01:09,954 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 15:01:09,955 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 15:01:09,957 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 15:01:09,958 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 15:01:09,960 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 15:01:09,961 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 15:01:09,961 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 15:01:09,962 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 15:01:09,963 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 15:01:09,964 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 15:01:09,965 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 15:01:09,966 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 15:01:09,967 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 15:01:09,968 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 15:01:09,969 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 15:01:09,970 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 15:01:09,971 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 15:01:09,972 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 15:01:09,973 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 15:01:09,975 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 15:01:09,975 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 15:01:09,977 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 15:01:09,978 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 15:01:09,978 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 15:01:09,979 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 15:01:09,980 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 15:01:09,981 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 15:01:09,982 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 15:01:09,983 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 15:01:09,984 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 15:01:09,984 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 15:01:09,985 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 15:01:09,986 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 15:01:09,987 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 15:01:09,987 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 15:01:09,988 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 15:01:09,989 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 15:01:09,995 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 15:01:09,997 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 15:01:09,997 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 15:01:09,999 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 15:01:09,999 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 15:01:10,000 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 15:01:10,257 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 15:01:10,257 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 15:01:10,258 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 15:01:10,363 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 15:01:10,364 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 15:01:10,364 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 15:01:10,449 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 15:01:10,449 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 15:01:10,449 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 15:01:10,512 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 15:01:10,512 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 15:01:10,512 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 15:01:10,513 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 15:01:10,560 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 15:01:10,561 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 15:01:10,561 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 15:01:10,561 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 15:01:10,561 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 15:01:10,568 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 15:01:10,568 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 15:01:10,569 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 15:01:10,569 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 15:01:10,569 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 15:01:10,569 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 15:01:10,569 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 15:01:10,569 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 15:01:10,569 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 15:01:10,570 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 15:01:10,570 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 15:01:10,570 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 15:01:10,570 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 15:01:10,570 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 15:01:10,570 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 15:01:10,570 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 15:01:10,571 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 15:01:10,571 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 15:01:10,571 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 15:01:10,571 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 15:01:10,571 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 15:01:10,571 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 15:01:10,571 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 15:01:10,571 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 15:01:10,593 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 15:01:10,593 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 15:01:10,593 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 15:01:10,607 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 15:01:10,607 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 15:01:10,607 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 15:01:10,607 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 15:01:10,607 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 15:01:10,607 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 15:01:10,607 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 15:01:10,608 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 15:01:10,615 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 15:01:10,615 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 15:01:10,616 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 15:01:10,617 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 15:01:10,617 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 15:01:10,620 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 15:01:10,621 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 15:01:10,621 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 15:01:10,621 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 15:01:10,621 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 15:01:10,621 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 15:01:10,621 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 15:01:10,622 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 15:01:10,622 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 15:01:10,622 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 15:01:10,622 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 15:01:11,808 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 15:01:11,808 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 15:01:11,809 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 15:02:03,789 [Thread-8] INFO  marytts.main Shutdown complete.
+2016-02-19 15:02:09,907 [JavaFX Application Thread] INFO  marytts.main Mary starting up...
+2016-02-19 15:02:09,912 [JavaFX Application Thread] INFO  marytts.main Specification version 5.1.2
+2016-02-19 15:02:09,912 [JavaFX Application Thread] INFO  marytts.main Implementation version unknown
+2016-02-19 15:02:09,912 [JavaFX Application Thread] INFO  marytts.main Running on a Java 1.8.0_45 implementation by Oracle Corporation, on a Windows 8 platform (amd64, 6.2)
+2016-02-19 15:02:10,005 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.Synthesis'
+2016-02-19 15:02:10,009 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TextToMaryXML'
+2016-02-19 15:02:10,010 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SableParser'
+2016-02-19 15:02:10,010 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SSMLParser'
+2016-02-19 15:02:10,011 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.APMLParser'
+2016-02-19 15:02:10,011 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.EmotionmlParser'
+2016-02-19 15:02:10,012 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JTokeniser'
+2016-02-19 15:02:10,013 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.DummyTokens2Words'
+2016-02-19 15:02:10,013 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.ProsodyGeneric'
+2016-02-19 15:02:10,016 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PronunciationModel'
+2016-02-19 15:02:10,017 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.TargetFeatureLister'
+2016-02-19 15:02:10,018 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HalfPhoneTargetFeatureLister'
+2016-02-19 15:02:10,019 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.AcousticModeller'
+2016-02-19 15:02:10,020 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedAcoustparamsExtractor'
+2016-02-19 15:02:10,020 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.RealisedDurationsExtractor'
+2016-02-19 15:02:10,021 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.HTSEngine'
+2016-02-19 15:02:10,022 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.PraatTextGridGenerator'
+2016-02-19 15:02:10,024 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.JTokeniser'
+2016-02-19 15:02:10,024 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.FreeTTSTokenToWords'
+2016-02-19 15:02:10,028 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_US.)'
+2016-02-19 15:02:10,029 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_US.txt' for locale 'en_US' does not exist. Ignoring.
+2016-02-19 15:02:10,102 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.JPhonemiser(en_GB.)'
+2016-02-19 15:02:10,102 [JavaFX Application Thread] INFO  marytts.JPhonemiser User dictionary '.\user-dictionaries\userdict-en_GB.txt' for locale 'en_GB' does not exist. Ignoring.
+2016-02-19 15:02:10,162 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Prosody'
+2016-02-19 15:02:10,163 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.SimplePhoneme2AP(en_US)'
+2016-02-19 15:02:10,165 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.Utt2XMLWordsEn'
+2016-02-19 15:02:10,168 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.XML2UttTokensEn'
+2016-02-19 15:02:10,172 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.language.en.PronunciationModel'
+2016-02-19 15:02:10,173 [JavaFX Application Thread] INFO  marytts.ModuleRegistry Now initiating mary module 'marytts.modules.OpenNLPPosTagger(en,en.pos)'
+2016-02-19 15:02:10,178 [JavaFX Application Thread] INFO  marytts.UnitSelectionSynthesizer started.
+2016-02-19 15:02:10,179 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->TARGETFEATURES, locale null).
+2016-02-19 15:02:10,179 [JavaFX Application Thread] INFO  marytts.HTSEngine Module started (TARGETFEATURES->AUDIO, locale null).
+2016-02-19 15:02:10,202 [JavaFX Application Thread] INFO  marytts.HMMData Loading Tree Set in CARTs:
+2016-02-19 15:02:10,317 [JavaFX Application Thread] INFO  marytts.HMMData Loading GV Model Set:
+2016-02-19 15:02:10,518 [JavaFX Application Thread] INFO  marytts.Voice Registering voice `cmu-slt-hsmm': female, locale en_US
+2016-02-19 15:02:10,534 [JavaFX Application Thread] INFO  marytts.Voice New default voice for locale en_US: cmu-slt-hsmm (desire 0)
+2016-02-19 15:02:10,534 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer started.
+2016-02-19 15:02:10,534 [JavaFX Application Thread] INFO  marytts.Synthesis Module started (ACOUSTPARAMS->AUDIO, locale null).
+2016-02-19 15:02:10,535 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Starting power-on self test.
+2016-02-19 15:02:10,568 [JavaFX Application Thread] INFO  marytts.HTSEngine Using prosody from acoustparams.
+2016-02-19 15:02:10,571 [JavaFX Application Thread] INFO  marytts.HTSEngine Number of models in sentence numModel=7  Total number of states numState=35
+2016-02-19 15:02:10,571 [JavaFX Application Thread] INFO  marytts.HTSEngine Total number of frames=147  Number of voiced frames=89
+2016-02-19 15:02:10,579 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Parameter generation for MGC: 
+2016-02-19 15:02:10,580 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 15:02:10,587 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=23
+2016-02-19 15:02:10,603 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=54
+2016-02-19 15:02:10,610 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=38
+2016-02-19 15:02:10,613 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=20
+2016-02-19 15:02:10,615 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=13
+2016-02-19 15:02:10,617 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (5)  number of iterations=21
+2016-02-19 15:02:10,620 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (6)  number of iterations=7
+2016-02-19 15:02:10,621 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (7)  number of iterations=4
+2016-02-19 15:02:10,622 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (8)  number of iterations=11
+2016-02-19 15:02:10,624 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (9)  number of iterations=19
+2016-02-19 15:02:10,625 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (10)  number of iterations=16
+2016-02-19 15:02:10,626 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (11)  number of iterations=9
+2016-02-19 15:02:10,627 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (12)  number of iterations=2
+2016-02-19 15:02:10,628 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (13)  number of iterations=13
+2016-02-19 15:02:10,629 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (14)  number of iterations=12
+2016-02-19 15:02:10,630 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (15)  number of iterations=14
+2016-02-19 15:02:10,631 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (16)  number of iterations=15
+2016-02-19 15:02:10,631 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (17)  number of iterations=14
+2016-02-19 15:02:10,632 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (18)  number of iterations=19
+2016-02-19 15:02:10,633 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (19)  number of iterations=12
+2016-02-19 15:02:10,634 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (20)  number of iterations=17
+2016-02-19 15:02:10,636 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (21)  number of iterations=23
+2016-02-19 15:02:10,637 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (22)  number of iterations=12
+2016-02-19 15:02:10,638 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (23)  number of iterations=18
+2016-02-19 15:02:10,639 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (24)  number of iterations=12
+2016-02-19 15:02:10,640 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (25)  number of iterations=11
+2016-02-19 15:02:10,641 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (26)  number of iterations=13
+2016-02-19 15:02:10,642 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (27)  number of iterations=9
+2016-02-19 15:02:10,643 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (28)  number of iterations=13
+2016-02-19 15:02:10,644 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (29)  number of iterations=8
+2016-02-19 15:02:10,645 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (30)  number of iterations=11
+2016-02-19 15:02:10,645 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (31)  number of iterations=12
+2016-02-19 15:02:10,646 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (32)  number of iterations=7
+2016-02-19 15:02:10,647 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (33)  number of iterations=8
+2016-02-19 15:02:10,648 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (34)  number of iterations=12
+2016-02-19 15:02:10,648 [JavaFX Application Thread] INFO  marytts.ParameterGeneration Using f0 from maryXML acoustparams
+2016-02-19 15:02:10,650 [JavaFX Application Thread] INFO  marytts.PStream Context-dependent global variance optimization: gvLength = 107
+2016-02-19 15:02:10,651 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (0)  number of iterations=16
+2016-02-19 15:02:10,652 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (1)  number of iterations=2
+2016-02-19 15:02:10,652 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (2)  number of iterations=2
+2016-02-19 15:02:10,653 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (3)  number of iterations=8
+2016-02-19 15:02:10,654 [JavaFX Application Thread] INFO  marytts.PStream Gradient GV optimization for feature: (4)  number of iterations=26
+2016-02-19 15:02:10,664 [JavaFX Application Thread] INFO  marytts.HMMSynthesizer Power-on self test complete.
+2016-02-19 15:02:10,665 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Module started (TEXT->RAWMARYXML, locale null).
+2016-02-19 15:02:10,665 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Starting power-on self test.
+2016-02-19 15:02:10,673 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 15:02:10,673 [JavaFX Application Thread] WARN  marytts.TextToMaryXML Locale is null, overriding with en_US
+2016-02-19 15:02:10,673 [JavaFX Application Thread] INFO  marytts.TextToMaryXML Power-on self test complete.
+2016-02-19 15:02:10,940 [JavaFX Application Thread] INFO  marytts.SableParser Module started (SABLE->RAWMARYXML, locale null).
+2016-02-19 15:02:10,940 [JavaFX Application Thread] INFO  marytts.SableParser Starting power-on self test.
+2016-02-19 15:02:10,940 [JavaFX Application Thread] INFO  marytts.SableParser Power-on self test complete.
+2016-02-19 15:02:11,046 [JavaFX Application Thread] INFO  marytts.SSMLParser Module started (SSML->RAWMARYXML, locale null).
+2016-02-19 15:02:11,046 [JavaFX Application Thread] INFO  marytts.SSMLParser Starting power-on self test.
+2016-02-19 15:02:11,046 [JavaFX Application Thread] INFO  marytts.SSMLParser Power-on self test complete.
+2016-02-19 15:02:11,131 [JavaFX Application Thread] INFO  marytts.APMLParser Module started (APML->RAWMARYXML, locale null).
+2016-02-19 15:02:11,131 [JavaFX Application Thread] INFO  marytts.APMLParser Starting power-on self test.
+2016-02-19 15:02:11,132 [JavaFX Application Thread] INFO  marytts.APMLParser Power-on self test complete.
+2016-02-19 15:02:11,190 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Module started (EMOTIONML->RAWMARYXML, locale null).
+2016-02-19 15:02:11,190 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Starting power-on self test.
+2016-02-19 15:02:11,191 [JavaFX Application Thread] INFO  marytts.EmotionmlParser Power-on self test complete.
+2016-02-19 15:02:11,191 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale null).
+2016-02-19 15:02:11,237 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 15:02:11,237 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 15:02:11,237 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Module started (TOKENS->WORDS, locale null).
+2016-02-19 15:02:11,237 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Starting power-on self test.
+2016-02-19 15:02:11,238 [JavaFX Application Thread] INFO  marytts.DummyTokens2Words Power-on self test complete.
+2016-02-19 15:02:11,245 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale null).
+2016-02-19 15:02:11,245 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 15:02:11,245 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 15:02:11,245 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale null).
+2016-02-19 15:02:11,245 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 15:02:11,245 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 15:02:11,246 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 15:02:11,246 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 15:02:11,246 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Module started (ACOUSTPARAMS->HALFPHONE_TARGETFEATURES, locale null).
+2016-02-19 15:02:11,246 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Starting power-on self test.
+2016-02-19 15:02:11,246 [JavaFX Application Thread] INFO  marytts.TargetFeatureLister Power-on self test complete.
+2016-02-19 15:02:11,246 [JavaFX Application Thread] INFO  marytts.AcousticModeller Module started (ALLOPHONES->ACOUSTPARAMS, locale null).
+2016-02-19 15:02:11,246 [JavaFX Application Thread] INFO  marytts.AcousticModeller Starting power-on self test.
+2016-02-19 15:02:11,247 [JavaFX Application Thread] INFO  marytts.AcousticModeller Power-on self test complete.
+2016-02-19 15:02:11,247 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Module started (AUDIO->REALISED_ACOUSTPARAMS, locale null).
+2016-02-19 15:02:11,247 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Starting power-on self test.
+2016-02-19 15:02:11,247 [JavaFX Application Thread] INFO  marytts.Realised acoustparams extractor Power-on self test complete.
+2016-02-19 15:02:11,247 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Module started (AUDIO->REALISED_DURATIONS, locale null).
+2016-02-19 15:02:11,247 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Starting power-on self test.
+2016-02-19 15:02:11,247 [JavaFX Application Thread] INFO  marytts.Realised durations extractor Power-on self test complete.
+2016-02-19 15:02:11,247 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Module started (AUDIO->PRAAT_TEXTGRID, locale null).
+2016-02-19 15:02:11,247 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Starting power-on self test.
+2016-02-19 15:02:11,248 [JavaFX Application Thread] INFO  marytts.Praat TextGrid generator Power-on self test complete.
+2016-02-19 15:02:11,248 [JavaFX Application Thread] INFO  marytts.JTokeniser Module started (RAWMARYXML->TOKENS, locale en).
+2016-02-19 15:02:11,273 [JavaFX Application Thread] INFO  marytts.JTokeniser Starting power-on self test.
+2016-02-19 15:02:11,273 [JavaFX Application Thread] INFO  marytts.JTokeniser Power-on self test complete.
+2016-02-19 15:02:11,274 [JavaFX Application Thread] INFO  marytts.TokenToWords Module started (FREETTS_TOKENS->FREETTS_WORDS, locale en).
+2016-02-19 15:02:11,287 [JavaFX Application Thread] INFO  marytts.TokenToWords Starting power-on self test.
+2016-02-19 15:02:11,287 [JavaFX Application Thread] INFO  marytts.TokenToWords Power-on self test complete.
+2016-02-19 15:02:11,288 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_US).
+2016-02-19 15:02:11,288 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 15:02:11,288 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 15:02:11,288 [JavaFX Application Thread] INFO  marytts.JPhonemiser Module started (PARTSOFSPEECH->PHONEMES, locale en_GB).
+2016-02-19 15:02:11,288 [JavaFX Application Thread] INFO  marytts.JPhonemiser Starting power-on self test.
+2016-02-19 15:02:11,288 [JavaFX Application Thread] INFO  marytts.JPhonemiser Power-on self test complete.
+2016-02-19 15:02:11,295 [JavaFX Application Thread] INFO  marytts.Prosody Module started (PHONEMES->INTONATION, locale en).
+2016-02-19 15:02:11,296 [JavaFX Application Thread] INFO  marytts.Prosody Starting power-on self test.
+2016-02-19 15:02:11,296 [JavaFX Application Thread] INFO  marytts.Prosody Power-on self test complete.
+2016-02-19 15:02:11,297 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Module started (SIMPLEPHONEMES->ACOUSTPARAMS, locale en_US).
+2016-02-19 15:02:11,297 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Starting power-on self test.
+2016-02-19 15:02:11,300 [JavaFX Application Thread] INFO  marytts.SimplePhoneme2AP Power-on self test complete.
+2016-02-19 15:02:11,302 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Module started (FREETTS_WORDS->WORDS, locale en).
+2016-02-19 15:02:11,302 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Starting power-on self test.
+2016-02-19 15:02:11,302 [JavaFX Application Thread] INFO  marytts.Utt2XML WordsEn Power-on self test complete.
+2016-02-19 15:02:11,302 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Module started (TOKENS->FREETTS_TOKENS, locale en).
+2016-02-19 15:02:11,302 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Starting power-on self test.
+2016-02-19 15:02:11,302 [JavaFX Application Thread] INFO  marytts.XML2Utt TokensEn Power-on self test complete.
+2016-02-19 15:02:11,302 [JavaFX Application Thread] INFO  marytts.PronunciationModel Module started (INTONATION->ALLOPHONES, locale en).
+2016-02-19 15:02:11,303 [JavaFX Application Thread] INFO  marytts.PronunciationModel Starting power-on self test.
+2016-02-19 15:02:11,303 [JavaFX Application Thread] INFO  marytts.PronunciationModel Power-on self test complete.
+2016-02-19 15:02:11,303 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Module started (WORDS->PARTSOFSPEECH, locale en).
+2016-02-19 15:02:12,495 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Starting power-on self test.
+2016-02-19 15:02:12,495 [JavaFX Application Thread] INFO  marytts.OpenNLPPosTagger Power-on self test complete.
+2016-02-19 15:02:12,496 [JavaFX Application Thread] INFO  marytts.main Startup complete.
+2016-02-19 15:05:41,998 [Thread-8] INFO  marytts.main Shutting down modules...
+2016-02-19 15:05:41,998 [Thread-8] INFO  marytts.Synthesis Module shut down.
+2016-02-19 15:05:41,998 [Thread-8] INFO  marytts.TextToMaryXML Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.SableParser Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.SSMLParser Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.APMLParser Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.EmotionmlParser Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.DummyTokens2Words Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.TargetFeatureLister Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.AcousticModeller Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.Realised acoustparams extractor Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.Realised durations extractor Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.HTSEngine Module shut down.
+2016-02-19 15:05:42,002 [Thread-8] INFO  marytts.Praat TextGrid generator Module shut down.
+2016-02-19 15:05:42,003 [Thread-8] INFO  marytts.JTokeniser Module shut down.
+2016-02-19 15:05:42,003 [Thread-8] INFO  marytts.TokenToWords Module shut down.
+2016-02-19 15:05:42,003 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 15:05:42,003 [Thread-8] INFO  marytts.JPhonemiser Module shut down.
+2016-02-19 15:05:42,006 [Thread-8] INFO  marytts.Prosody Module shut down.
+2016-02-19 15:05:42,006 [Thread-8] INFO  marytts.SimplePhoneme2AP Module shut down.
+2016-02-19 15:05:42,006 [Thread-8] INFO  marytts.Utt2XML WordsEn Module shut down.
+2016-02-19 15:05:42,006 [Thread-8] INFO  marytts.XML2Utt TokensEn Module shut down.
+2016-02-19 15:05:42,006 [Thread-8] INFO  marytts.PronunciationModel Module shut down.
+2016-02-19 15:05:42,006 [Thread-8] INFO  marytts.OpenNLPPosTagger Module shut down.
+2016-02-19 15:05:42,008 [Thread-8] INFO  marytts.main Shutdown complete.

--- a/shootoff.properties
+++ b/shootoff.properties
@@ -1,14 +1,16 @@
 #ShootOFF Configuration
-#Sat Oct 24 11:38:28 EDT 2015
+#Fri Feb 19 14:54:13 PST 2016
+shootoff.diagnosticmessages.chime.muted=
+shootoff.redlasersound=D\:\\GitHub\\ShootOFF\\sounds\\walther_ppq.wav
 shootoff.webcams=
-shootoff.redlasersound=sounds/walther_ppq.wav
-shootoff.firstrun=true
-shootoff.errorreporting=true
+shootoff.firstrun=false
+shootoff.ipcams=
 shootoff.malfunctions.probability=10.0
-shootoff.greenlasersound=sounds/walther_ppq.wav
+shootoff.greenlasersound=D\:\\GitHub\\ShootOFF\\sounds\\walther_ppq.wav
 shootoff.greenlasersound.use=false
-shootoff.ignorelasercolor=None
+shootoff.ignorelasercolor=green
 shootoff.markerradius=4
+shootoff.errorreporting=false
 shootoff.virtualmagazine.use=false
 shootoff.malfunctions.use=false
 shootoff.virtualmagazine.capacity=7

--- a/src/main/java/com/shootoff/gui/controller/ShootOFFController.java
+++ b/src/main/java/com/shootoff/gui/controller/ShootOFFController.java
@@ -62,6 +62,7 @@ import com.shootoff.plugins.ShootDontShoot;
 import com.shootoff.plugins.ShootForScore;
 import com.shootoff.plugins.SteelChallenge;
 import com.shootoff.plugins.TimedHolsterDrill;
+import com.shootoff.plugins.TossUP;
 import com.shootoff.plugins.TrainingExercise;
 import com.shootoff.plugins.TrainingExerciseBase;
 import com.shootoff.session.SessionRecorder;
@@ -621,6 +622,7 @@ public class ShootOFFController implements CameraConfigListener, TargetListener 
 	}
 
 	private void registerProjectorExercises() {
+		addProjectorTrainingExercise(new TossUP());
 		addProjectorTrainingExercise(new BouncingTargets());
 		addProjectorTrainingExercise(new DuelingTree());
 		addProjectorTrainingExercise(new ShootDontShoot());

--- a/src/main/java/com/shootoff/plugins/ProjectorTrainingExerciseBase.java
+++ b/src/main/java/com/shootoff/plugins/ProjectorTrainingExerciseBase.java
@@ -65,6 +65,11 @@ public class ProjectorTrainingExerciseBase extends TrainingExerciseBase {
 		this.arenaController = arenaController;
 	}
 
+	public ProjectorArenaController getProjArenaController(){
+		return this.arenaController;
+	}
+	
+	
 	@Override
 	public void reset() {
 		camerasSupervisor.reset();

--- a/src/main/java/com/shootoff/plugins/TossUP.java
+++ b/src/main/java/com/shootoff/plugins/TossUP.java
@@ -1,0 +1,765 @@
+/*TossUP by ifly53e*/
+
+package com.shootoff.plugins;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.geometry.Bounds;
+import javafx.geometry.HPos;
+import javafx.geometry.Point2D;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.paint.Color;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.util.Duration;
+import com.shootoff.camera.Shot;
+import com.shootoff.gui.LocatedImage;
+import com.shootoff.gui.Target;
+import com.shootoff.targets.ImageRegion;
+import com.shootoff.targets.RegionType;
+import com.shootoff.targets.TargetRegion;
+import java.util.concurrent.Callable;
+
+public class TossUP extends ProjectorTrainingExerciseBase implements TrainingExercise {
+	private static int penalty = 5;
+	private boolean troubleshootingReset = false;
+	final int MAX_TARGETS = 20;
+	final int DEFAULT_TARGET_COUNT = 2;//4 - 1;
+	final int DEFAULT_TIME_BETWEEN_TARGET_MOVEMENT = 6;//1 - 1;
+	final int DEFAULT_MAX_ROUNDS = 19;
+	final String DEFAULT_TARGET_STRING = "ISSF";
+	final String DEFAULT_SCALE = "three-quarter";
+	private int default_target_count_reset = DEFAULT_TARGET_COUNT;
+	private int default_time_between_target_movement_reset = DEFAULT_TIME_BETWEEN_TARGET_MOVEMENT;
+	private int default_max_rounds_reset = DEFAULT_MAX_ROUNDS;
+	private String addTargetString_reset = DEFAULT_TARGET_STRING;
+	private String theScale_reset = DEFAULT_SCALE;
+	private final static String POINTS_COL_NAME = "Score";
+	private final static int POINTS_COL_WIDTH = 60;
+	private boolean fromReset = false;
+	private String addTargetString = "nothing here";
+	private String theScale = "nothing here";
+	private int shootCount = 3;
+	private int roundCount = 5;
+	private int timeBetweenTargetMovement = 9;
+	private int misses = 0;
+	private int hits = 0;
+	private double newScale = 0;
+	private int decRoundCount = 0;
+	private static int edgeProtection = 50;
+	public double targetX = 0;
+	public double targetY = 0;
+	public double consolidatedX = 0;
+	public double consolidatedY = 0;
+	public static long beepTimeStatic = 0;
+	public List<Point2D> consolidatedList = new ArrayList<Point2D> ();
+	public Map<String, List<Point2D>> theMap = new HashMap<String, List<Point2D>>();
+	public Map<String, Point2D> targetLocationMap = new HashMap<String, Point2D>();
+	public Map<String, TossUPTarget> cttMap = new HashMap<String, TossUPTarget>();
+	private double shotX = 0;
+	private double shotY = 0;
+	private long beepTime = 0;
+	private long finishTime = 0;
+	private static final List<TossUPTarget> shootTargets = new ArrayList<TossUPTarget>();
+	private static final List<TossUPTarget> dontShootTargets = new ArrayList<TossUPTarget>();
+	private static final List<Timeline> myTimelineList = new ArrayList<Timeline>();
+
+	private static ProjectorTrainingExerciseBase thisSuper;
+	private Timeline targetAnimation;
+	private int score = 0;
+	private int possiblePoints = 0;
+
+	private boolean testing = false;
+
+	private static Label myLabel = new Label("hello");
+
+	private static int canvasGroupSize = 0;
+
+	public TossUP() {}
+
+	public TossUP(List<Group> targets) {
+		super(targets);
+		setThisSuper(super.getInstance());
+	}
+
+	// For testing
+	protected void init(int shootCount, int timeBetweenTargetMovement, int maxVelocity) {
+
+		testing = true;
+		this.shootCount = shootCount;
+		this.timeBetweenTargetMovement = timeBetweenTargetMovement;
+		shootTargets.clear();
+		startExercise();
+
+	}
+
+	private static void setThisSuper(ProjectorTrainingExerciseBase thisSuper) {
+		TossUP.thisSuper = thisSuper;
+	}
+
+	private void initColumn(){
+		if (!fromReset){
+		super.addShotTimerColumn(POINTS_COL_NAME, POINTS_COL_WIDTH);
+		}
+	}
+
+	@Override
+	public void init() {
+		thisSuper.getProjArenaController().setBackground(new LocatedImage("file:\\ShootOFF-master\\src\\main\\resources\\arena\\backgrounds\\hickok45_autumn.gif"));
+		initColumn();
+		collectSettings();
+		startExercise();
+	}//end init
+
+	private void startExercise()  {
+
+		long scoreTime = finishTime-beepTime;
+		if (scoreTime < 0)scoreTime = 0;
+		//super.showTextOnFeed(String.format("Score: %d  Misses: %d Hits: %d Points Possible: %d Deduction: %d", score-((roundCount*shootCount-hits)*penalty),misses,hits,possiblePoints,((roundCount*shootCount-hits)*penalty) ));
+		
+		if(shootCount == 6){ //possible 45 points
+			possiblePoints = 45;
+			addTargets(shootTargets,"targets/TossUP_chicken.target",1);
+			addTargets(shootTargets,"targets/TossUP_Turkey_Silhouette.target",1);
+			addTargets(shootTargets,"targets/TossUP_pig_silhouette.target",1);
+			addTargets(shootTargets,"targets/TossUP_ram_silhouette.target",1);
+			addTargets(shootTargets,"targets/TossUP_silhouette-plate.target",1);
+			addTargets(shootTargets,"targets/TossUP_Pepper_Popper.target",1);
+		}
+		if(shootCount == 5){ //35 points
+			possiblePoints = 35;
+			addTargets(shootTargets,"targets/TossUP_Turkey_Silhouette.target",1);
+			addTargets(shootTargets,"targets/TossUP_pig_silhouette.target",1);
+			addTargets(shootTargets,"targets/TossUP_ram_silhouette.target",1);
+			addTargets(shootTargets,"targets/TossUP_silhouette-plate.target",1);
+			addTargets(shootTargets,"targets/TossUP_Pepper_Popper.target",1);
+		}
+		if(shootCount == 4){ //26
+			possiblePoints = 26;
+			addTargets(shootTargets,"targets/TossUP_pig_silhouette.target",1);
+			addTargets(shootTargets,"targets/TossUP_ram_silhouette.target",1);
+			addTargets(shootTargets,"targets/TossUP_silhouette-plate.target",1);
+			addTargets(shootTargets,"targets/TossUP_Pepper_Popper.target",1);
+		}
+		if(shootCount == 3){//18
+			possiblePoints = 18;
+			addTargets(shootTargets,"targets/TossUP_ram_silhouette.target",1);
+			addTargets(shootTargets,"targets/TossUP_silhouette-plate.target",1);
+			addTargets(shootTargets,"targets/TossUP_Pepper_Popper.target",1);
+		}
+		if(shootCount == 2){//11
+			possiblePoints = 11;
+			addTargets(shootTargets,"targets/TossUP_silhouette-plate.target",1);
+			addTargets(shootTargets,"targets/TossUP_Pepper_Popper.target",1);
+		}
+		if(shootCount == 1){//5
+			possiblePoints = 5;
+			addTargets(shootTargets,"targets/TossUP_Pepper_Popper.target",1);
+		}
+
+		myLabel = thisSuper.getProjArenaController().getCanvasManager().addProjectorMessage(String.format("Score: %d", score), Color.YELLOW);
+
+		thisSuper.getProjArenaController().getCanvasManager().hideProjectorMessage(myLabel);
+
+		targetAnimation = new Timeline(new KeyFrame(Duration.millis(timeBetweenTargetMovement * 1000), e -> updateTargets()));
+		targetAnimation.setCycleCount(roundCount);
+
+		playSound("sounds/voice/shootoff-makeready.wav");
+		try {
+			Thread.sleep((long) 3500.);
+		} catch (InterruptedException e1) {
+			e1.printStackTrace();
+		}
+		playSound("sounds/beep.wav");
+
+		targetAnimation.play();
+		updateTargets();
+
+		pauseShotDetection(false);
+		beepTime = System.currentTimeMillis();
+		beepTimeStatic = beepTime;
+
+	}//end start exercise
+
+
+//	protected class PlayTheTimeline implements Callable<Void> {
+//		Timeline theTimeline = new Timeline();
+//
+//		public PlayTheTimeline(Timeline t){
+//			this.theTimeline.equals(t);
+//		}
+//		@Override
+//		public Void call(){
+//			theTimeline.play();//playTheTimeline(theTimeline);
+//			return null;
+//		}
+//
+//		public Void call(Timeline timelineToPlay) throws Exception {
+//			timelineToPlay.play();
+//			return null;
+//		}
+//	}
+
+	private void collectSettings() {
+		super.pauseShotDetection(true);
+
+		final Stage TossUPTargetsStage = new Stage();
+		final GridPane TossUPTargetsPane = new GridPane();
+		final ColumnConstraints cc = new ColumnConstraints(200);
+		final ObservableList<String> targetList = FXCollections.observableArrayList();
+		final ComboBox<String> targetListComboBox = new ComboBox<String>(targetList);
+		final ObservableList<String> shootCountList = FXCollections.observableArrayList();
+		final ObservableList<String> roundCountList = FXCollections.observableArrayList();
+		final ComboBox<String> shootTargetsComboBox = new ComboBox<String>(shootCountList);
+		final ObservableList<String> maxScale = FXCollections.observableArrayList();
+		final ComboBox<String> maxScaleComboBox = new ComboBox<String>(maxScale);
+		final ComboBox<String> numberOfRoundsComboBox = new ComboBox<String>(roundCountList);//ok to use between 1 and 10
+		final Scene scene = new Scene(TossUPTargetsPane);
+		final Button okButton = new Button("OK");
+
+			cc.setHalignment(HPos.LEFT);
+			TossUPTargetsPane.getColumnConstraints().addAll(new ColumnConstraints(), cc);
+
+			for (int i = 1; i <= 6; i++){
+				shootCountList.add(Integer.toString(i));
+			}
+
+			for (int i = 1; i <= MAX_TARGETS; i++){
+				roundCountList.add(Integer.toString(i));
+			}
+
+			shootTargetsComboBox.getSelectionModel().select(default_target_count_reset);
+			TossUPTargetsPane.add(new Label("Number of Targets:"), 0, 0);
+			TossUPTargetsPane.add(shootTargetsComboBox, 1, 0);
+			//shootTargetsComboBox.setVisible(false);
+
+			maxScale.add("one-quarter");
+			maxScale.add("one-half");
+			maxScale.add("three-quarter");
+			maxScale.add("original");
+			maxScale.add("double");
+
+			maxScaleComboBox.getSelectionModel().select(theScale_reset);
+			TossUPTargetsPane.add(new Label("Target Scale:"), 0, 2);
+			TossUPTargetsPane.add(maxScaleComboBox, 1, 2);
+
+			numberOfRoundsComboBox.getSelectionModel().select(default_max_rounds_reset);
+			TossUPTargetsPane.add(new Label("Target Rounds:"), 0, 3);
+			TossUPTargetsPane.add(numberOfRoundsComboBox, 1, 3);
+
+			okButton.setDefaultButton(true);
+			TossUPTargetsPane.add(okButton, 1, 6);
+
+		okButton.setOnAction((e) -> {
+			addTargetString =  targetListComboBox.getSelectionModel().getSelectedItem();
+			shootCount = Integer.parseInt(shootTargetsComboBox.getSelectionModel().getSelectedItem());
+			//timeBetweenTargetMovement = Integer.parseInt(targetTimeComboBox.getSelectionModel().getSelectedItem());
+			theScale = maxScaleComboBox.getSelectionModel().getSelectedItem();
+			roundCount = Integer.parseInt(numberOfRoundsComboBox.getSelectionModel().getSelectedItem());
+
+			TossUPTargetsStage.close();
+		});//end OKButton
+
+		TossUPTargetsStage.initOwner(super.getShootOFFStage());
+		TossUPTargetsStage.initModality(Modality.WINDOW_MODAL);
+		TossUPTargetsStage.setTitle("TossUP Target Settings");
+		TossUPTargetsStage.setScene(scene);
+		TossUPTargetsStage.showAndWait();
+
+		addTargetString_reset = addTargetString;
+		default_target_count_reset = shootCount -1;
+		default_time_between_target_movement_reset = timeBetweenTargetMovement -1;
+		theScale_reset = theScale;
+		default_max_rounds_reset = roundCount -1;
+		decRoundCount = roundCount;
+		score = 0;
+
+	}//end collectSettings
+
+	protected List<TossUPTarget> getShootTargets() {
+		return shootTargets;
+	}
+
+	//kept in so I did not break TestBouncingTargets...
+	protected List<TossUPTarget> getDontShootTargets() {
+		return dontShootTargets;
+	}
+
+	private void moveTargetUp(TossUPTarget ctt){
+		ctt.moveTargetUp();
+
+	}
+
+	private void updateTargets() {
+		decRoundCount--;
+
+		//stop the shooting and present user with consolidated target
+		if(decRoundCount < 0) {
+			finishTime = System.currentTimeMillis();
+
+			targetAnimation.stop();
+			for(TossUPTarget ctt2 : shootTargets){
+				ctt2.cttTimeline.stop();
+			}
+			super.pauseShotDetection(true);
+			long scoreTime = finishTime-beepTime;
+			if (scoreTime < 0)scoreTime = 0;
+			double hitPercentage = 0;
+			if (hits+misses !=0) hitPercentage = hits/(double)(hits+misses)*100;
+			super.showTextOnFeed(String.format("Total Shots Fired: %d%n Hits: %d%n Misses: %d%n Hit Percentage: %f%n Points Possible: %d%n Total Targets: %d%n Targets Not Hit: %d%n Targets Not Hit Deduction: %d%n  Shots Missed Deduction %d%n Score: %d ",misses+hits ,hits,misses,hitPercentage,possiblePoints*roundCount,roundCount*shootCount,roundCount*shootCount-hits,((roundCount*shootCount-hits)*penalty),misses*5,score-((roundCount*shootCount-hits)*penalty)-misses*5 ));
+			
+			thisSuper.getProjArenaController().getCanvasManager().setShowShots(true);
+
+			//make the shots go away for a cleaner picture
+			for (Shot shot : thisSuper.getProjArenaController().getCanvasManager().getShots()) {
+				shot.getMarker().setVisible(false);
+			}
+
+			//reset the target animations so the targets pop back up
+			for (TossUPTarget target : shootTargets) {
+				for (Node node : target.getTarget().getTargetGroup().getChildren()) {
+					TargetRegion r = (TargetRegion) node;
+					if(r.getType()==RegionType.IMAGE){
+						ImageRegion myIR = (ImageRegion) r;
+						myIR.getAnimation().get().reset();
+					}
+				}
+			}
+
+			//so we can remove the shots we added later
+			canvasGroupSize = thisSuper.getProjArenaController().getCanvasManager().getCanvasGroup().getChildren().size();
+
+			int incX=100;
+			//line up the targets
+			for (TossUPTarget b : shootTargets){
+				File theFile = b.getTarget().getTargetFile();
+				String theFileName = theFile.getName();//  getAbsolutePath();//  getName();
+				b.getTarget().setPosition(incX,400);
+				for(Map.Entry<String, List<Point2D>> e: theMap.entrySet()){
+					if(theFileName.compareToIgnoreCase(e.getKey())==0 ){
+						//super.showTextOnFeed(String.format("theFileName was found inside update: %s",theFileName));
+							for (Point2D p2d : e.getValue()){
+								thisSuper.getProjArenaController().getCanvasManager().getCanvasGroup().getChildren().add(new javafx.scene.shape.Circle(p2d.getX()+incX, p2d.getY()+400,10,Color.YELLOW));
+							}//end for
+						//}//end for
+					}//end if
+				}//end for
+
+				incX=incX+225;
+			}//end for
+
+			//total shots fired = hits plus misses
+			//total hits
+			//total misses
+			//hit percentage  = hits/shots fired
+			
+			//possible points = possiblePoints * roundCount
+			//possible targets to hit = roundcount * shootcount
+			//total targets not hit = (roundCount * shootCount) - hits
+			//penalty for not hitting targets = ((roundCount * shootCount) - hits)*5
+			//penalty for misses = misses*5
+			//score
+			
+			myLabel.setText(String.format("Total Shots Fired: %d%n Hits: %d%n Misses: %d%n Hit Percentage: %f%n Points Possible: %d%n Total Targets: %d%n Targets Not Hit: %d%n Targets Not Hit Deduction: %d%n  Shots Missed Deduction %d%n Score: %d ",misses+hits ,hits,misses,hitPercentage,possiblePoints*roundCount,roundCount*shootCount,roundCount*shootCount-hits,((roundCount*shootCount-hits)*penalty),misses*5,score-((roundCount*shootCount-hits)*penalty)-misses*5 ));
+			thisSuper.getProjArenaController().getCanvasManager().showProjectorMessage(myLabel);
+			return;
+		}//end if
+
+		for (TossUPTarget b : shootTargets){
+			b.moveTarget();
+		}
+
+		//to reset the round time
+		beepTimeStatic = System.currentTimeMillis();
+	}//end updateTargets
+
+	public static int getRandom(int from, int to) {
+		Random theRandom = new Random();
+	    if (from < to)
+	        return from + theRandom.nextInt(Math.abs(to - from));
+	    return from - theRandom.nextInt(Math.abs(to - from));
+	}
+
+	private enum CollisionType {
+		NONE, COLLISION_X, COLLISION_Y, COLLISION_BOTH;
+	}
+
+	private static CollisionType checkCollision(Optional<Target> newTarget) {
+		final Bounds targetBounds = newTarget.get().getTargetGroup().getBoundsInParent();
+
+		List<TossUPTarget> collisionList;
+		collisionList = shootTargets;
+
+		for (TossUPTarget b : collisionList) {
+			if (b.getTarget().equals(newTarget)) continue;
+
+			if(b.getTarget().getPosition().equals(newTarget.get().getPosition()))continue;
+
+			final Bounds bBounds = b.getTarget().getTargetGroup().getBoundsInParent();
+
+			//thisSuper.showTextOnFeed(String.format("bounds newTarget, bounds listTarget %s, %s", targetBounds.toString(),bBounds.toString()));
+
+			if (targetBounds.intersects(bBounds)) {
+				final boolean atRight = targetBounds.getMaxX() > bBounds.getMinX();
+				final boolean atLeft = bBounds.getMaxX() > bBounds.getMinX();
+				final boolean atBottom = targetBounds.getMaxY() > bBounds.getMinY();
+				final boolean atTop = bBounds.getMaxY() > targetBounds.getMinY();
+
+				if ((atRight || atLeft) && (atBottom || atTop)) {
+					return CollisionType.COLLISION_BOTH;
+				} else if (atRight || atLeft) {
+					return CollisionType.COLLISION_X;
+				} else if (atBottom || atTop) {
+					return CollisionType.COLLISION_Y;
+				}
+			}
+		}
+
+		return CollisionType.NONE;
+	}
+
+	protected static class TossUPTarget {
+		private final Target target;
+		private int launchVelocity = 150;//seems to control the launch angle better than launch degrees
+		private double angleOfLaunchDegrees = 90;
+		private double gravity = 25;//13,800 top, 17,800 .8, 21,800 .6 30
+		private double projectileY = 0;
+		private double moveTargetTime = 0;
+		private double angleInRads = 0;
+		private double targetSpeed = 150.0;//between 100 and 200 works best
+		private double yMove = 1;
+		Timeline cttTimeline = new Timeline(new KeyFrame(Duration.millis(20), e -> moveTargetUp() ));
+		private double delayTime = 0;
+		private double startTime = 0;
+		private boolean targetWasHit = false;
+		
+		public void setTargetWasHit(boolean theFlag)
+		{
+			this.targetWasHit = theFlag;
+		}
+
+		public boolean getTargetWasHit()
+		{
+			return this.targetWasHit;
+		}
+
+		public void setGravity(double theGravity)
+		{
+			this.gravity = theGravity;
+		}
+
+		public double getGravity()
+		{
+			return this.gravity;
+		}
+
+		public TossUPTarget(Target target) {
+			this.target = target;
+		}
+
+		public Target getTarget() {
+			return this.target;
+		}
+
+		//called by b.moveTarget()
+		public void moveTarget() {
+
+			CollisionType ct = CollisionType.COLLISION_X;
+			while(ct ==CollisionType.COLLISION_BOTH || ct == CollisionType.COLLISION_X  ){
+				int maxX = (int) (thisSuper.getArenaWidth() - this.getTarget().getDimension().getWidth() - edgeProtection);
+
+				Random myRandom1 = new Random();
+				int x = myRandom1.nextInt(maxX + 1) + 1;
+				this.getTarget().setPosition(x, 1200);
+				
+				this.setGravity(getRandom(9,15));
+
+				ct = checkCollision(Optional.of(this.getTarget()));
+
+				//thisSuper.showTextOnFeed("inside moveTarget collisionLoop: "+x+" ,"+ct.toString());
+			}
+
+		if (this.getTargetWasHit()){
+				for (Node node : this.getTarget().getTargetGroup().getChildren()) {
+					TargetRegion r = (TargetRegion) node;
+					if(r.getType()==RegionType.IMAGE){
+						ImageRegion myIR = (ImageRegion) r;
+						myIR.getAnimation().get().reset();
+					}//end if
+				}//end for
+				this.setTargetWasHit(false);
+			}//end if targetWasHIt
+
+			this.cttTimeline.stop();
+			int randomDelay = getRandom(10,30);
+			this.delayTime = randomDelay;
+			//thisSuper.showTextOnFeed("the delay is: "+randomDelay);
+			this.cttTimeline.setDelay(new Duration( (double)randomDelay*100));
+			this.cttTimeline.play();
+			this.startTime = System.currentTimeMillis();
+
+		}//end moveTarget
+		
+		//called by update
+		public void moveTargetUp() {
+
+			angleInRads = angleOfLaunchDegrees * 3.14159/180;
+
+			moveTargetTime = (System.currentTimeMillis() - delayTime*100 - startTime)/targetSpeed;//beepTimeStatic)/targetSpeed;
+
+			projectileY =  ( (launchVelocity*Math.sin(angleInRads)*moveTargetTime - getGravity()*moveTargetTime*moveTargetTime/2.0)*-1 ) / yMove;
+
+			target.setPosition(target.getPosition().getX(), 1200+projectileY);
+
+		}//end moveTarget
+	}//end class TossUPTargets
+
+	private void addTargets(List<TossUPTarget> targets, String target, int count) {
+		for (int i = 0; i < count; i++) {
+			Optional<Target> newTarget = super.addTarget(new File(target), 0, 0);
+
+			if (newTarget.isPresent()) {
+
+				TossUPTarget theNewCtt = new TossUPTarget(newTarget.get());
+
+				theNewCtt.cttTimeline = new Timeline(new KeyFrame(Duration.millis(20), e -> moveTargetUp(theNewCtt) ));
+				theNewCtt.cttTimeline.setCycleCount(Timeline.INDEFINITE);
+				myTimelineList.add(theNewCtt.cttTimeline);
+				cttMap.put(target.substring(target.indexOf("/")+1), theNewCtt);
+
+				targets.add(theNewCtt);
+				targets.get(targets.size()-1).setGravity(getRandom(9,15));
+				super.showTextOnFeed("gravity is: "+targets.get(targets.size()-1).getGravity());
+
+				//scale the target
+				if(theScale == "one-half")newScale = 0.5;
+				if(theScale == "one-quarter")newScale = 0.25;
+				if(theScale == "three-quarter")newScale = 0.75;
+				if(theScale == "original")newScale = 1.0;
+				if(theScale == "double")newScale = 2.0;
+
+				//newTarget.get().setDimensions(newTarget.get().getDimension().getWidth() * newScale, newTarget.get().getDimension().getHeight() * newScale);
+
+				newTarget.get().getTargetGroup().setScaleX(newScale);
+				newTarget.get().getTargetGroup().setScaleY(newScale);
+
+				// Randomly place the target with no overlap
+				CollisionType myCT = CollisionType.COLLISION_X;
+				int maxX,x=0,maxY,y = 0;
+				while(myCT ==CollisionType.COLLISION_BOTH || myCT == CollisionType.COLLISION_X ){
+					maxX = (int) (super.getArenaWidth() - newTarget.get().getDimension().getWidth() - edgeProtection);
+					x = new Random().nextInt(maxX + 1) + 1;
+					maxY = (int) (super.getArenaHeight() - newTarget.get().getDimension().getHeight() - edgeProtection);
+					y = new Random().nextInt(maxY + 1) + 1;
+					newTarget.get().setPosition(x, 1200);
+					myCT = checkCollision(newTarget);
+					//thisSuper.showTextOnFeed("inside addTargets collisionLoop");
+				}
+
+				targetLocationMap.put(target.substring(target.indexOf("/")+1), new Point2D(x,y));
+
+
+				//using the filename as the key
+				theMap.put(target.substring(target.indexOf("/")+1), new ArrayList<Point2D>());
+
+			}//end if
+		}//end for
+	}//end function
+
+	@Override
+	public ExerciseMetadata getInfo() {
+		return new ExerciseMetadata("TossUP", "1.0", "ifly53e",
+				"This exercise randomly moves six silhouette targets at a user specified interval around the projector arena."
+					+ "Hit the targets as quickly as possible to move to the next round of randomly placed targets."
+					+ "The targets will disappear after the target face time expires."
+					+ "The rounds are the number of cycles in which targets will be presented."
+					+ "You can scale the targets to be bigger or smaller "
+					+ "Scoring:  Each target is worth 10 points."
+					+ "A target that is not hit is minus 10 points.  All misses are minus five points."
+					+ "A time bonus is added to your score based on how quickly all targets are hit.");
+		//TODO:
+		//add a screen count down to start...currently stopping thread for a few seconds
+		//figure out how to reset and start over the exercise from hitting a reset target
+	}
+
+	@Override
+	public void shotListener(Shot shot, Optional<TargetRegion> hitRegion) {
+		//targetWasHit = true;
+
+//		if(hitRegion.isPresent()){
+//			if(hitRegion.get().getType() == RegionType.ELLIPSE)super.showTextOnFeed("ELLIPSE");
+//			if(hitRegion.get().getType() == RegionType.IMAGE)super.showTextOnFeed("IMAGE");
+//			if(hitRegion.get().tagExists("name"))super.showTextOnFeed("Name is present:"+hitRegion.get().getTag("name"));
+//			if(hitRegion.get().tagExists("subtarget"))super.showTextOnFeed("Subtarget is present:"+hitRegion.get().getTag("subtarget"));
+//		}
+
+		if (hitRegion.isPresent()) {
+			if (shot.getColor().equals(Color.RED)) {
+				hits++;
+				if (hitRegion.get().tagExists("points")) {
+
+					super.setShotTimerColumnText(POINTS_COL_NAME, hitRegion.get().getTag("points"));
+					score += Integer.parseInt(hitRegion.get().getTag("points"));
+
+				}//end if tagexists points
+				else{
+					score = score + 10;
+				}//end else<tag name="points" value="2" />
+				long scoreTime = finishTime-beepTime;
+				if (scoreTime < 0)scoreTime = 0;
+				//super.showTextOnFeed(String.format("Score: %d  Misses: %d Hits: %d Points Possible: %d Deduction: %d", score-((roundCount*shootCount-hits)*penalty),misses,hits,possiblePoints,((roundCount*shootCount-hits)*penalty) ));
+				
+				if(hitRegion.get().tagExists("name")){
+					TossUPTarget myCtt;
+					switch(hitRegion.get().getTag("name")){
+
+						case "TossUP_silhouette-plate.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("name"));
+							myCtt.setTargetWasHit(true);
+						break;
+						case "TossUP_ram_silhouette.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("name"));
+							myCtt.setTargetWasHit(true);
+						break;
+						case "TossUP_pig_silhouette.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("name"));
+							myCtt.setTargetWasHit(true);
+						break;
+						case "TossUP_chicken.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("name"));
+							myCtt.setTargetWasHit(true);
+						break;
+						case "TossUP_Turkey_Silhouette.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("name"));
+							myCtt.setTargetWasHit(true);
+						break;
+						case "TossUP_Pepper_Popper.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("name"));
+							myCtt.setTargetWasHit(true);
+						break;
+					}//end switch
+
+					List<Point2D> myTempList = new ArrayList<Point2D>();
+					myTempList = theMap.get( hitRegion.get().getTag("name"));//get the list of points from the map for the target that was hit
+					//get the location of that target as soon as you can
+					if(myTempList !=null){
+						myTempList.add(new Point2D(hitRegion.get().getRegionImpactX(), hitRegion.get().getRegionImpactY() ));
+						theMap.put( hitRegion.get().getTag("name"), myTempList);
+					}
+					super.showTextOnFeed(String.format("NAME hitx: %d, shotX: %f, hity: %d, shoty: %f",hitRegion.get().getRegionImpactX(),shotX,hitRegion.get().getRegionImpactY(),shotY));
+				}
+				if(hitRegion.get().tagExists("subtarget")){
+					TossUPTarget myCtt;
+					switch(hitRegion.get().getTag("subtarget")){
+
+						case "TossUP_silhouette-plate.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("subtarget"));
+							myCtt.setTargetWasHit(true);
+						break;
+						case "TossUP_ram_silhouette.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("subtarget"));
+							myCtt.setTargetWasHit(true);
+						break;
+						case "TossUP_pig_silhouette.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("subtarget"));
+							myCtt.setTargetWasHit(true);
+						break;
+						case "TossUP_chicken.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("subtarget"));
+							myCtt.setTargetWasHit(true);
+						break;
+						case "TossUP_Turkey_Silhouette.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("subtarget"));
+							myCtt.setTargetWasHit(true);
+						break;
+						case "TossUP_Pepper_Popper.target":
+							myCtt = cttMap.get(hitRegion.get().getTag("subtarget"));
+							myCtt.setTargetWasHit(true);
+						break;
+					}//end switch
+
+					List<Point2D> myTempList1 = new ArrayList<Point2D>();
+					myTempList1 = theMap.get( hitRegion.get().getTag("subtarget"));//get the list of points from the map for the target that was hit
+					//get the location of that target as soon as you can
+					myTempList1.add(new Point2D(hitRegion.get().getRegionImpactX(), hitRegion.get().getRegionImpactY() ));
+					theMap.put( hitRegion.get().getTag("subtarget"), myTempList1);
+					super.showTextOnFeed(String.format("SUB  hitx: %d, shotX: %f, hity: %d, shoty: %f",hitRegion.get().getRegionImpactX(),shotX,hitRegion.get().getRegionImpactY(),shotY));
+				}
+
+				return;
+			}//end if
+
+		}//end if hitRegion.isPresent
+		else{
+			//its a miss
+			if (shot.getColor().equals(Color.RED)) {
+				score = score - 5;
+				misses++;
+				long scoreTime = finishTime-beepTime;
+				if (scoreTime < 0)scoreTime = 0;
+				//super.showTextOnFeed(String.format("Score: %d  Misses: %d Hits: %d Points Possible: %d Deduction: %d", score-((roundCount*shootCount-hits)*penalty),misses,hits,possiblePoints,((roundCount*shootCount-hits)*penalty) ));
+			}//end if
+
+		}//end else
+	}//end function
+
+	@Override
+	public void reset(List<Group> targets) {
+		reset();
+	}
+	@Override
+	public void reset() {
+		targetAnimation.stop();
+
+		//clean up the shots we added
+		//super.showTextOnFeed("canvasGroupSize before: "+canvasGroupSize +" after:"+thisSuper.getProjArenaController().getCanvasManager().getCanvasGroup().getChildren().size());
+		for (int i = thisSuper.getProjArenaController().getCanvasManager().getCanvasGroup().getChildren().size(); i>canvasGroupSize;i-- ) {
+			//super.showTextOnFeed("removed node in reset"+i);
+			thisSuper.getProjArenaController().getCanvasManager().getCanvasGroup().getChildren().remove(thisSuper.getProjArenaController().getCanvasManager().getCanvasGroup().getChildren().size()-1);
+		}
+
+		for (TossUPTarget b : shootTargets)
+			super.removeTarget(b.getTarget());
+		shootTargets.clear();
+
+		consolidatedList.clear();
+
+		//shots.clear wont work for the projector arena so do it manually
+
+		if(!troubleshootingReset){
+			for (Shot shot : thisSuper.getProjArenaController().getCanvasManager().getShots() ) {
+				if(thisSuper.getProjArenaController().getCanvasManager().getCanvasGroup().getChildren().contains(shot.getMarker()) ){
+					thisSuper.getProjArenaController().getCanvasManager().getCanvasGroup().getChildren().remove(shot.getMarker());
+				}//endif
+			}//end for
+		}//end iff
+
+		this.getProjArenaController().getCanvasManager().getShots().clear();
+		thisSuper.getProjArenaController().getCanvasManager().removeProjectorMessage(myLabel);
+		//myLabel = thisSuper.getProjArenaController().getCanvasManager().addProjectorMessage(String.format("Score: %d", score), Color.YELLOW); //getCanvasGroup().getChildren().set(1,myLabel);
+
+		fromReset = true;
+		getProjArenaController().getCanvasManager().setShowShots(false);
+		hits = 0;
+		misses = 0;
+		init();
+
+	}//end reset
+
+}//end public class TossUP

--- a/src/main/java/com/shootoff/targets/EllipseRegion.java
+++ b/src/main/java/com/shootoff/targets/EllipseRegion.java
@@ -31,6 +31,27 @@ public class EllipseRegion extends Ellipse implements TargetRegion {
 
 		super(centerX, centerY, radiusX, radiusY);
 	}
+	private int regionImpactX = 0;
+	private int regionImpactY = 0;
+	
+	@Override
+	public void setRegionImpactX(int newImpactX){
+		this.regionImpactX = newImpactX;
+	}
+
+	@Override
+	public void setRegionImpactY(int newImpactY){
+		this.regionImpactY = newImpactY;
+	}
+
+	@Override
+	public int getRegionImpactX(){
+		return this.regionImpactX;
+	}
+	@Override
+	public int getRegionImpactY(){
+		return this.regionImpactY;
+	}
 
 	@Override
 	public void changeWidth(double widthDelta) {
@@ -67,4 +88,5 @@ public class EllipseRegion extends Ellipse implements TargetRegion {
 		tags.clear();
 		tags.putAll(newTags);
 	}
+
 }

--- a/src/main/java/com/shootoff/targets/ImageRegion.java
+++ b/src/main/java/com/shootoff/targets/ImageRegion.java
@@ -58,6 +58,28 @@ public class ImageRegion extends ImageView implements TargetRegion {
 		}
 	}
 
+	private int regionImpactX = 0;
+	private int regionImpactY = 0;
+	
+	@Override
+	public void setRegionImpactX(int newImpactX){
+		this.regionImpactX = newImpactX;
+	}
+
+	@Override
+	public void setRegionImpactY(int newImpactY){
+		this.regionImpactY = newImpactY;
+	}
+
+	@Override
+	public int getRegionImpactX(){
+		return this.regionImpactX;
+	}
+	@Override
+	public int getRegionImpactY(){
+		return this.regionImpactY;
+	}
+
 	public boolean onFirstFrame() {
 		if (!animation.isPresent()) {
 			return true;

--- a/src/main/java/com/shootoff/targets/PolygonRegion.java
+++ b/src/main/java/com/shootoff/targets/PolygonRegion.java
@@ -48,6 +48,27 @@ public class PolygonRegion extends Polygon implements TargetRegion {
 
 		this.setScaleX(this.getScaleX() * scaleFactor);
 	}
+	private int regionImpactX = 0;
+	private int regionImpactY = 0;
+	
+	@Override
+	public void setRegionImpactX(int newImpactX){
+		this.regionImpactX = newImpactX;
+	}
+
+	@Override
+	public void setRegionImpactY(int newImpactY){
+		this.regionImpactY = newImpactY;
+	}
+
+	@Override
+	public int getRegionImpactX(){
+		return this.regionImpactX;
+	}
+	@Override
+	public int getRegionImpactY(){
+		return this.regionImpactY;
+	}
 
 	@Override
 	public void changeHeight(double heightDelta) {

--- a/src/main/java/com/shootoff/targets/RectangleRegion.java
+++ b/src/main/java/com/shootoff/targets/RectangleRegion.java
@@ -29,6 +29,27 @@ public class RectangleRegion extends Rectangle implements TargetRegion {
 	public RectangleRegion(double x, double y, double width, double height) {
 		super(x, y, width, height);
 	}
+	private int regionImpactX = 0;
+	private int regionImpactY = 0;
+	
+	@Override
+	public void setRegionImpactX(int newImpactX){
+		this.regionImpactX = newImpactX;
+	}
+
+	@Override
+	public void setRegionImpactY(int newImpactY){
+		this.regionImpactY = newImpactY;
+	}
+
+	@Override
+	public int getRegionImpactX(){
+		return this.regionImpactX;
+	}
+	@Override
+	public int getRegionImpactY(){
+		return this.regionImpactY;
+	}
 
 	@Override
 	public void changeWidth(double widthDelta) {

--- a/src/main/java/com/shootoff/targets/TargetRegion.java
+++ b/src/main/java/com/shootoff/targets/TargetRegion.java
@@ -39,4 +39,12 @@ public interface TargetRegion {
 	public Map<String, String> getAllTags();
 
 	public void setTags(Map<String, String> newTags);
+
+	public int getRegionImpactX();
+
+	public int getRegionImpactY();
+	
+	public void setRegionImpactX(int newImpact);
+	
+	public void setRegionImpactY(int newImpact);
 }

--- a/targets/TossUP_Pepper_Popper.target
+++ b/targets/TossUP_Pepper_Popper.target
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<target>
+	<image x="0.000000" y="0.000000" file="targets/pepper_popper.gif">
+		<tag name="name" value="TossUP_Pepper_Popper.target" />
+		<tag name="command" value="animate;play_sound(sounds/steel_sound_1.wav)" />
+		<tag name="points" value="5" />
+	</image>
+</target>

--- a/targets/TossUP_Pig_Silhouette.target
+++ b/targets/TossUP_Pig_Silhouette.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<target>
+	<ellipse centerX="60.000000" centerY="40.000000" radiusX="100.000000" radiusY="120.000000" fill="black">
+		<tag name="subtarget" value="TossUP_pig_silhouette.target" />
+		<tag name="points" value="8" />
+		<tag name="opacity" value=".005" />
+		<tag name="visible" value="true"/>
+		<tag name="command" value="animate(TossUP_pig_silhouette.target);play_sound(sounds/beep.wav);" />
+	</ellipse>
+	<image x="0.000000" y="0.000000" file="targets/pig.gif">
+		<tag name="command" value="animate;play_sound(sounds/steel_sound_1.wav);" />
+		<tag name="name" value="TossUP_pig_silhouette.target" />
+		<tag name="points" value="8" />
+	</image>
+</target>

--- a/targets/TossUP_Ram_Silhouette.target
+++ b/targets/TossUP_Ram_Silhouette.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<target>
+	<ellipse centerX="80.000000" centerY="80.000000" radiusX="136.000000" radiusY="136.000000" fill="black">
+		<tag name="subtarget" value="TossUP_ram_silhouette.target" />
+		<tag name="points" value="7" />
+		<tag name="opacity" value=".005" />
+		<tag name="visible" value="true"/>
+		<tag name="command" value="animate(TossUP_ram_silhouette.target);play_sound(sounds/beep.wav);" />
+	</ellipse>
+	<image x="0.000000" y="0.000000" file="targets/ram.gif">
+		<tag name="command" value="animate;play_sound(sounds/steel_sound_1.wav);" />
+		<tag name="name" value="TossUP_ram_silhouette.target" />
+		<tag name="points" value="7" />
+	</image>
+</target>

--- a/targets/TossUP_Turkey_Silhouette.target
+++ b/targets/TossUP_Turkey_Silhouette.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<target>
+	<ellipse centerX="60.00000" centerY="60.000000" radiusX="90.000000" radiusY="136.000000" fill="black">
+		<tag name="subtarget" value="TossUP_Turkey_Silhouette.target" />
+		<tag name="opacity" value=".005" />
+		<tag name="visible" value="true"/>
+		<tag name="command" value="animate(TossUP_Turkey_Silhouette.target);play_sound(sounds/beep.wav);" />
+		<tag name="points" value="9" />
+	</ellipse>
+	<image x="0.000000" y="0.000000" file="targets/turkey.gif">
+		<tag name="command" value="animate;play_sound(sounds/steel_sound_1.wav);" />
+		<tag name="name" value="TossUP_Turkey_Silhouette.target" />
+		<tag name="points" value="9" />
+	</image>
+</target>

--- a/targets/TossUP_chicken.target
+++ b/targets/TossUP_chicken.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<target>
+	<ellipse centerX="40.000000" centerY="30.000000" radiusX="50.000000" radiusY="100.000000" fill="black">
+		<tag name="subtarget" value="TossUP_chicken.target" />
+		<tag name="points" value="10" />
+		<tag name="opacity" value=".005" />
+		<tag name="visible" value="true"/>
+		<tag name="command" value="animate(TossUP_chicken.target);play_sound(sounds/beep.wav);" />
+	</ellipse>
+	<image x="0.000000" y="0.000000" file="targets/chicken.gif">
+		<tag name="command" value="animate;play_sound(sounds/steel_sound_1.wav);" />
+		<tag name="name" value="TossUP_chicken.target" />
+		<tag name="points" value="10" />
+	</image>
+</target>

--- a/targets/TossUP_silhouette-plate.target
+++ b/targets/TossUP_silhouette-plate.target
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<target>
+	<image x="0.000000" y="0.000000" file="targets/silhouette-plate.gif">
+		<tag name="command" value="animate;play_sound(sounds/steel_sound_1.wav)" />
+		<tag name="points" value="6" />
+		<tag name="name" value="TossUP_silhouette-plate.target" />
+	</image>
+</target>


### PR DESCRIPTION
Just want to get some feedback...I don't really expect for these changes to be merged to the master but I want to discuss them with the team.

This is probably a good candidate for a 3.8 module.  Targets are "thrown" into the air and come back down.  This was an effort to create a speed drill and partially satisfy the "duck hunt"
issue.

The motion of the targets that are thrown in the air causes false green shots.  I currently ignore green lasers in the preferences.

There is significant lag when targets are moving fast.  I replicated this in bouncing targets as well.  A shot on the trailing edge of the fast moving target will not produce a hit.  To compensate for this, I have an ellipse coupled with the image in the target file so when the user hits the gif on the screen, the lag will show the hit in the ellipse and the user gets credit for it.

To create the "report card of hits" at the end of a round, I needed a way to get the location of the shot when it was found in the hit region
of the target.  This is already done in the canvasManager so I added a regionImpact x and y in the interface of the targetRegion along with
gets and sets so the canvasManager can record the impact coordinates in the TargetRegion.  If the shotListener was provided the Hit instead of
only the targetRegion, this would not be necessary.  My changes only require changes to the regions, not the existing training exercises
(like a new overloaded shotListener would require) so I did not overload the shotListener to return the Hit instead.  Either way, I would get
what I needed.
