### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 branches:
   only:
   - master
-script: travis_wait 45 gradle check
+script: gradle check
 before_script:
   - gradle --version
   # Have ssh trust our deployment server
@@ -26,3 +26,8 @@ after_success:
   - gradle zipRelease -x test
   - mv build/dist/shootoff-*-final.zip shootoff-nightly-$(date +'%m%d%Y').zip
   - sshpass -e scp shootoff-nightly-$(date +'%m%d%Y').zip nightlies@dev.shootoffapp.com:~/continuous-deployment-page/nightlies
+
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
