### PR TITLE
Fix/linux pop os support, idryfire camera etc.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     compile group: 'com.google.code.findbugs', name: 'annotations', version: '3.+'
 
     // Raven, exception reporting client (requires logback)
-    compile group: 'com.getsentry.raven', name: 'raven-logback', version: '7.+'
+    //compile group: 'com.getsentry.raven', name: 'raven-logback', version: '7.+'
 
     // Logback to enable exception reporting
     compile group: 'ch.qos.logback', name: 'logback-core', version: '1.+'

--- a/build.gradle
+++ b/build.gradle
@@ -54,15 +54,8 @@ def tsaURL = 'http://timestamp.comodoca.com/rfc3161'
 
 repositories {
     mavenCentral()
-    // This repository is directly included even though we use jcenter
-    // because it makes it easier to get the smallest set of marytts that
-    // meets our needs without missing the freetts dependency
-    maven {
-        url  "https://dl.bintray.com/marytts/marytts/"
-    }
-    maven {
-        url "https://dl.bintray.com/phrack/maven/"
-    }
+    // Bintray is defunct — marytts artifacts are available on Maven Central
+    // and the DFKI Maven repo below. The phrack repo is no longer needed.
     maven {
         url "https://maven.dcm4che.org/"
     }
@@ -201,6 +194,23 @@ task updateJars() {
                 }
             }
         }
+    }
+}
+
+task simpleJar(type: Jar, dependsOn: [build, 'copyConfig', 'copyTargets', 'copyCourses', 'copySounds', 'copyLibs', 'copyEyeCam']) {
+    description 'Create a runnable jar for ShootOFF (without ant-javafx)'
+    group 'Package'
+
+    destinationDirectory = file('build/dist')
+    archiveFileName = 'ShootOFF.jar'
+
+    from sourceSets.main.output
+
+    manifest {
+        attributes(
+            'Main-Class': mainClassName,
+            'Class-Path': configurations.runtimeClasspath.collect { 'libs/' + it.name }.join(' ')
+        )
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,14 @@
-import groovyx.gpars.GParsPool
-import groovy.xml.NamespaceBuilder
-import org.kohsuke.github.GitHub
-import org.ajoberstar.grgit.Grgit
-import org.ajoberstar.grgit.Credentials
-
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
-            url  "http://repo.jenkins-ci.org/releases/"
+            url  "https://repo.jenkins-ci.org/releases/"
         }
     }
     dependencies {
         classpath group: 'org.codehaus.gpars', name: 'gpars', version: '1.1.0'
         classpath group: 'org.kohsuke', name: 'github-api', version: '1.+'
     }
-}
-
-plugins {
-    id 'org.ajoberstar.grgit' version '1.3.2'
 }
 
 apply plugin: 'java'
@@ -63,15 +53,27 @@ def keyAlias = 'cscert'
 def tsaURL = 'http://timestamp.comodoca.com/rfc3161'
 
 repositories {
-    jcenter()
+    mavenCentral()
     // This repository is directly included even though we use jcenter
     // because it makes it easier to get the smallest set of marytts that
     // meets our needs without missing the freetts dependency
     maven {
-        url  "http://dl.bintray.com/marytts/marytts/"
+        url  "https://dl.bintray.com/marytts/marytts/"
     }
     maven {
         url "https://dl.bintray.com/phrack/maven/"
+    }
+    maven {
+        url "https://maven.dcm4che.org/"
+    }
+    maven {
+        url "https://raw.githubusercontent.com/DFKI-MLT/Maven-Repository/main/"
+    }
+    maven {
+        url "https://nrgxnat.jfrog.io/artifactory/libs-release/"
+    }
+    maven {
+        url "https://nexus.terrestris.de/repository/public/"
     }
 }
 
@@ -80,69 +82,69 @@ configurations {
 
     // Some dependencies (webcam-capture and marytts?) pull in slf4j implementations that conflict
     // with logback
-    compile.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    implementation.exclude group: 'org.slf4j', module: 'slf4j-log4j12'
 }
 
 dependencies {
     jfxant files("$javaHome" + "/../lib/ant-javafx.jar")
 
     // FindBugs annotations to suppress warnings
-    compile group: 'com.google.code.findbugs', name: 'annotations', version: '3.+'
+    implementation group: 'com.google.code.findbugs', name: 'annotations', version: '3.+'
 
     // Raven, exception reporting client (requires logback)
-    //compile group: 'com.getsentry.raven', name: 'raven-logback', version: '7.+'
+    //implementation group: 'com.getsentry.raven', name: 'raven-logback', version: '7.+'
 
     // Logback to enable exception reporting
-    compile group: 'ch.qos.logback', name: 'logback-core', version: '1.+'
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.+'
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.12'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.12'
 
     // bridj is here because webcam-capture depends on it but fetches 0.6.2, which
     // does not play nicely with stackguard in newer versions of the JVM.
-    compile group: 'com.nativelibs4java', name: 'bridj', version: '0.7.0'
-    compile group: 'com.github.sarxos', name: 'webcam-capture', version: '0.3.+'
-    compile group: 'com.github.sarxos', name: 'webcam-capture-driver-ipcam', version: '0.3.+'
-    compile group: 'com.github.sarxos', name: 'webcam-capture-driver-v4l4j', version: '0.3.+'
+    implementation group: 'com.nativelibs4java', name: 'bridj', version: '0.7.0'
+    implementation group: 'com.github.sarxos', name: 'webcam-capture', version: '0.3.+'
+    implementation group: 'com.github.sarxos', name: 'webcam-capture-driver-ipcam', version: '0.3.+'
+    implementation group: 'com.github.sarxos', name: 'webcam-capture-driver-v4l4j', version: '0.3.+'
 
-    compile group: 'commons-cli', name: 'commons-cli', version: '1.+'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.+'
-    compile group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.+'
+    implementation group: 'commons-cli', name: 'commons-cli', version: '1.+'
+    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.+'
+    implementation group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.+'
 
     // tts dependencies
-    compile group: 'de.dfki.mary', name: 'marytts-runtime', version: '5.1.+'
-    compile group: 'de.dfki.mary', name: 'marytts-lang-en', version: '5.1.+'
-    compile group: 'de.dfki.mary', name: 'voice-cmu-slt-hsmm', version: '5.1.+'
+    implementation group: 'de.dfki.mary', name: 'marytts-runtime', version: '5.2.+'
+    implementation group: 'de.dfki.mary', name: 'marytts-lang-en', version: '5.2.+'
+    implementation group: 'de.dfki.mary', name: 'voice-cmu-slt-hsmm', version: '5.2.+'
 
     // xuggle for recording and playing back video
-    compile group: 'xuggle', name: 'xuggle-xuggler', version: '5.4'
+    implementation group: 'xuggle', name: 'xuggle-xuggler', version: '5.4'
 
     // JSON
-    compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1+'
+    implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1+'
 
     // OpenImaj
-    compile('org.openimaj:core:1.+') {
+    implementation('org.openimaj:core:1.+') {
         // OpenImaj transitive dependency that we don't need and that doesn't seem to exist in
         // repos anymore
         exclude group: 'vigna.dsi.unimi.it'
     }
 
     //OpenCV
-    compile 'org.openpnp:opencv:2.4.+'
+    implementation 'org.openpnp:opencv:2.4.+'
 
     // OSHI to collect HW and system state data
-    compile group: 'com.github.dblock', name: 'oshi-core', version: '3.+'
+    implementation group: 'com.github.dblock', name: 'oshi-core', version: '3.+'
 
     // JSoup to get processor benchmark data
-    compile group: 'org.jsoup', name: 'jsoup', version: '1.+'
-    
-    // Bluetooth libraries, QR code generator, and JSON serializer for headless mode
-    compile 'net.sf.bluecove:bluecove:2.1.0'
-    // Assumption that headless mode will only be supported on Linux
-    compile 'net.sf.bluecove:bluecove-gpl:2.1.0'
-    compile 'com.google.zxing:core:3.3.0'
-    compile 'com.google.code.gson:gson:2.8.0'
+    implementation group: 'org.jsoup', name: 'jsoup', version: '1.+'
 
-    testCompile group: 'junit', name: 'junit', version: '4.+'
-    testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: '1.+'
+    // Bluetooth libraries, QR code generator, and JSON serializer for headless mode
+    implementation 'net.sf.bluecove:bluecove:2.1.0'
+    // Assumption that headless mode will only be supported on Linux
+    implementation 'net.sf.bluecove:bluecove-gpl:2.1.0'
+    implementation 'com.google.zxing:core:3.3.0'
+    implementation 'com.google.code.gson:gson:2.8.0'
+
+    testImplementation group: 'junit', name: 'junit', version: '4.+'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: '1.+'
 }
 
 test {
@@ -177,7 +179,7 @@ task copySounds(type:Copy) {
 }
 
 task copyLibs(type:Copy) {
-    from { configurations.default.collect { it.isDirectory() ? it : it } }
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : it } }
     into libTempDir
     exclude "*jfxrt.jar"
     exclude "*java2html.jar"
@@ -213,11 +215,11 @@ task fxJar(dependsOn: build) {
     description 'Create a runnable jar for ShootOFF'
     group 'Package'
 
-    inputs.dir sourceSets.main.output.classesDir
+    inputs.files sourceSets.main.output.classesDirs
     inputs.dir sourceSets.main.output.resourcesDir
     outputs.file archivePath
 
-    def antfx = NamespaceBuilder.newInstance(
+    def antfx = groovy.xml.NamespaceBuilder.newInstance(
             ant,
             'javafx:com.sun.javafx.tools.ant')
 
@@ -234,7 +236,9 @@ task fxJar(dependsOn: build) {
 
         antfx.jar(destfile: archivePath) {
             application(refid: project.name)
-            fileset(dir: sourceSets.main.output.classesDir)
+            sourceSets.main.output.classesDirs.each { classDir ->
+                fileset(dir: classDir)
+            }
             fileset(dir: sourceSets.main.output.resourcesDir)
             antfx.resources() {
                 fileset(dir: 'build/dist/', includes: 'libs/*.jar')
@@ -270,8 +274,8 @@ task zipRelease(type: Zip) {
         include 'eyeCam64.dll'
     }
 
-    archiveName = releaseZip
-    destinationDir = file(dist)
+    archiveFileName = releaseZip
+    destinationDirectory = file(dist)
 }
 
 task getDiagnosticJar() {
@@ -286,7 +290,7 @@ task getDiagnosticJar() {
 	            password = new String(password)
 	        }
 
-	        gh = GitHub.connectUsingPassword(username, password)
+	        gh = org.kohsuke.github.GitHub.connectUsingPassword(username, password)
 
 	        if (!gh.isCredentialValid()) {
 	            throw new InvalidUserDataException('Incorrect GitHub credentials')
@@ -329,7 +333,7 @@ task pushZipRelease(dependsOn: zipRelease) {
             password = new String(password)
         }
 
-        if (!gh) gh = GitHub.connectUsingPassword(username, password)
+        if (!gh) gh = org.kohsuke.github.GitHub.connectUsingPassword(username, password)
 
         if (!gh.isCredentialValid()) {
             throw new InvalidUserDataException('Incorrect GitHub credentials')
@@ -364,7 +368,7 @@ task pushZipRelease(dependsOn: zipRelease) {
 
         // Update version metadata
 
-        grgit = Grgit.open('.', new Credentials(username: username, password: password))
+        grgit = org.ajoberstar.grgit.Grgit.open(file('.'))
         grgit.checkout(branch: 'gh-pages', createBranch: false)
 
         def versionMetadata = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n' +
@@ -406,7 +410,7 @@ task fxSignedJar(dependsOn: fxJar) {
 }
 
 task fxJarWritableResources() {
-    def antfx = NamespaceBuilder.newInstance(
+    def antfx = groovy.xml.NamespaceBuilder.newInstance(
             ant,
             'javafx:com.sun.javafx.tools.ant')
 
@@ -431,7 +435,7 @@ task msiRelease() {
     dependsOn('updateJars')
     dependsOn(getDiagnosticJar)
 
-    def antfx = NamespaceBuilder.newInstance(
+    def antfx = groovy.xml.NamespaceBuilder.newInstance(
             ant,
             'javafx:com.sun.javafx.tools.ant')
 
@@ -558,7 +562,7 @@ task fxWebstartSignedJar() {
                 )
         }
 
-        GParsPool.withPool {
+        groovyx.gpars.GParsPool.withPool {
             path.list().eachParallel { f ->
                 def antLocal = project.createAntBuilder()
                 antLocal.signjar(
@@ -574,7 +578,7 @@ task fxWebstartSignedJar() {
 }
 
 task fxRelease(dependsOn: fxWebstartSignedJar) {
-    def antfx = NamespaceBuilder.newInstance(
+    def antfx = groovy.xml.NamespaceBuilder.newInstance(
             ant,
             'javafx:com.sun.javafx.tools.ant')
 
@@ -678,7 +682,7 @@ task pushFxRelease(dependsOn: fxRelease) {
             password = new String(password)
         }
 
-        grgit = Grgit.open('.', new Credentials(username: username, password: password))
+        grgit = org.ajoberstar.grgit.Grgit.open(file('.'))
         grgit.checkout(branch: 'gh-pages', createBranch: false)
 
         delete jwsDir + 'libs'

--- a/shootoff.sh
+++ b/shootoff.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# ShootOFF launcher for Linux
+# Finds and preloads v4l1compat.so automatically
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Find v4l1compat.so
+V4L_PATHS=(
+    "/usr/lib/libv4l/v4l1compat.so"
+    "/usr/lib/x86_64-linux-gnu/libv4l/v4l1compat.so"
+    "/usr/lib/aarch64-linux-gnu/libv4l/v4l1compat.so"
+    "/usr/lib/i386-linux-gnu/libv4l/v4l1compat.so"
+)
+
+V4L_COMPAT=""
+for path in "${V4L_PATHS[@]}"; do
+    if [ -f "$path" ]; then
+        V4L_COMPAT="$path"
+        break
+    fi
+done
+
+if [ -z "$V4L_COMPAT" ]; then
+    # Try to find it dynamically
+    V4L_COMPAT=$(find /usr/lib -name "v4l1compat.so" 2>/dev/null | head -1)
+fi
+
+if [ -n "$V4L_COMPAT" ]; then
+    echo "Using v4l1compat: $V4L_COMPAT"
+    export LD_PRELOAD="$V4L_COMPAT"
+else
+    echo "WARNING: v4l1compat.so not found. Camera may not work."
+    echo "Install it with: sudo apt install libv4l-0"
+fi
+
+cd "$SCRIPT_DIR"
+exec java -jar build/dist/ShootOFF.jar "$@"

--- a/src/main/java/com/shootoff/Main.java
+++ b/src/main/java/com/shootoff/Main.java
@@ -50,8 +50,6 @@ import com.shootoff.plugins.TextToSpeech;
 import com.shootoff.util.HardwareData;
 import com.shootoff.util.SystemInfo;
 import com.shootoff.util.VersionChecker;
-import com.sun.deploy.uitoolkit.impl.fx.HostServicesFactory;
-import com.sun.javafx.application.HostServicesDelegate;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javafx.application.Application;
@@ -520,8 +518,7 @@ public class Main extends Application {
 				final Hyperlink lnk = new Hyperlink(link);
 
 				lnk.setOnAction((event) -> {
-					final HostServicesDelegate hostServices = HostServicesFactory.getInstance(this);
-					hostServices.showDocument(link);
+					getHostServices().showDocument(link);
 					lnk.setVisited(true);
 				});
 

--- a/src/main/java/com/shootoff/Main.java
+++ b/src/main/java/com/shootoff/Main.java
@@ -546,7 +546,8 @@ public class Main extends Application {
 			return;
 		}
 
-		if (version.isPresent() && !config.inDebugMode() && !isJWS) checkVersion();
+		// shootoffapp.com is defunct — skip the version check
+		// if (version.isPresent() && !config.inDebugMode() && !isJWS) checkVersion();
 
 		// This initializes the TTS engine
 		TextToSpeech.say("");
@@ -785,18 +786,31 @@ public class Main extends Application {
 			CameraFactory.getDefault();
 		} else if (SystemInfo.isLinux()) {
 			// Need to ensure v4l1compat is preloaded if it exists otherwise
-			// OpenCV won't work
-			final File v4lCompat = new File("/usr/lib/libv4l/v4l1compat.so");
+			// OpenCV won't work. Check multiple known paths since distros
+			// vary in where they install this library.
+			final String[] v4lPaths = {
+				"/usr/lib/libv4l/v4l1compat.so",
+				"/usr/lib/x86_64-linux-gnu/libv4l/v4l1compat.so",
+				"/usr/lib/aarch64-linux-gnu/libv4l/v4l1compat.so",
+				"/usr/lib/i386-linux-gnu/libv4l/v4l1compat.so"
+			};
 
-			if (v4lCompat.exists()) {
+			File v4lCompat = null;
+			for (final String path : v4lPaths) {
+				final File candidate = new File(path);
+				if (candidate.exists()) {
+					v4lCompat = candidate;
+					break;
+				}
+			}
+
+			if (v4lCompat != null) {
 				final String preload = System.getenv("LD_PRELOAD");
 
 				if (preload == null || !preload.contains(v4lCompat.getPath())) {
 					closeNoV4lCompat(v4lCompat);
 				}
 			} else {
-				// The over-exuberance here is because a lot of people miss this
-				// message
 				logger.warn("!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"
 						+ "This system is running Linux, and likely therefore also v4l. "
 						+ "If ShootOFF fails to run or has camera problems, it's likely because you need "

--- a/src/main/java/com/shootoff/camera/CameraFactory.java
+++ b/src/main/java/com/shootoff/camera/CameraFactory.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.sarxos.webcam.Webcam;
 import com.github.sarxos.webcam.WebcamCompositeDriver;
+import com.github.sarxos.webcam.WebcamDiscoveryService;
 import com.github.sarxos.webcam.ds.buildin.WebcamDefaultDriver;
 import com.github.sarxos.webcam.ds.ipcam.IpCamDevice;
 import com.github.sarxos.webcam.ds.ipcam.IpCamDriver;
@@ -51,6 +52,10 @@ public final class CameraFactory {
 	private static final boolean isMac;
 	private static Webcam defaultWebcam = null;
 	private static List<Camera> knownWebcams;
+	// Cache of sarxos Webcam objects from initial discovery (Linux).
+	// Re-calling Webcam.getWebcams() after stopping the discovery service
+	// can fail, so we cache the result.
+	private static List<Webcam> cachedSarxosWebcams = null;
 
 	private static List<Camera> openCameras = Collections.synchronizedList(new ArrayList<>());
 
@@ -106,9 +111,10 @@ public final class CameraFactory {
 			else
 				defaultCam = new SarxosCaptureCamera(defaultWebcam.getName());
 		} else {
-			final Webcam cam = Webcam.getDefault();
-
-			defaultCam = cam == null ? null : new SarxosCaptureCamera(cam.getName());
+			// Use getWebcams() instead of Webcam.getDefault() to avoid
+			// re-triggering discovery after we've stopped the service
+			final List<Camera> all = getWebcams();
+			defaultCam = all.isEmpty() ? null : all.get(0);
 		}
 
 		if (defaultCam == null && !registeredCameras.isEmpty()) {
@@ -123,8 +129,19 @@ public final class CameraFactory {
 
 		final List<Camera> webcams = new ArrayList<>();
 
+		if (cachedSarxosWebcams == null) {
+			cachedSarxosWebcams = Webcam.getWebcams();
+
+			// Stop the background discovery service to prevent it from leaking
+			// V4L2 file descriptors on Linux. The bridj V4L2 driver opens devices
+			// during periodic scans but doesn't always close them, exhausting the
+			// 16-device limit and preventing ffmpeg from accessing cameras.
+			stopDiscoveryService();
+		}
+		final List<Webcam> sarxosWebcams = cachedSarxosWebcams;
+
 		int cameraIndex = 0;
-		for (final Webcam w : Webcam.getWebcams()) {
+		for (final Webcam w : sarxosWebcams) {
 			final Camera c;
 			if (w.getDevice() instanceof IpCamDevice)
 				c = new IpCamera(w);
@@ -162,6 +179,18 @@ public final class CameraFactory {
 	public static void openCamerasAdd(Camera camera) {
 		synchronized (openCameras) {
 			if (!openCameras.contains(camera)) openCameras.add(camera);
+		}
+	}
+
+	private static void stopDiscoveryService() {
+		try {
+			final WebcamDiscoveryService ds = Webcam.getDiscoveryServiceRef();
+			if (ds != null && ds.isRunning()) {
+				ds.stop();
+				logger.info("Stopped webcam discovery service to prevent V4L2 FD leak");
+			}
+		} catch (final Exception e) {
+			logger.warn("Could not stop webcam discovery service", e);
 		}
 	}
 

--- a/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
+++ b/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
@@ -231,6 +231,7 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 			try {
 				final ProcessBuilder pb = new ProcessBuilder(
 					"ffmpeg",
+					"-loglevel", "error",
 					"-f", "v4l2",
 					"-video_size", res[0] + "x" + res[1],
 					"-i", devicePath,
@@ -240,6 +241,8 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 					"-"
 				);
 				pb.redirectErrorStream(false);
+				// Send ffmpeg's stderr to /dev/null to prevent buffer fill-up
+				pb.redirectError(new java.io.File("/dev/null"));
 				final Process proc = pb.start();
 
 				// Read a test frame to verify it works
@@ -261,6 +264,14 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 					ffmpegHeight = res[1];
 					usingFfmpegFallback = true;
 					logger.info("ffmpeg fallback opened at {}x{} for {}", res[0], res[1], devicePath);
+
+					// Ensure ffmpeg is killed when JVM exits
+					Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+						if (ffmpegProcess != null && ffmpegProcess.isAlive()) {
+							ffmpegProcess.destroyForcibly();
+						}
+					}));
+
 					return true;
 				} else {
 					logger.warn("ffmpeg fallback could not read full frame at {}x{} (got {} of {} bytes)",

--- a/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
+++ b/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
@@ -185,30 +185,37 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 		closing.set(false);
 
-		// Try OpenCV first
-		boolean open = camera.open(cameraIndex);
+		boolean open = false;
 
-		if (open) {
-			// Verify we can actually read a frame
-			final Mat testFrame = new Mat();
-			boolean canRead = false;
-			for (int i = 0; i < 3; i++) {
-				if (camera.read(testFrame) && testFrame.size().height > 0) {
-					canRead = true;
-					break;
-				}
-				try { Thread.sleep(100); } catch (InterruptedException ignored) {}
-			}
-			if (!canRead) {
-				logger.warn("OpenCV opened device {} but cannot read frames, trying ffmpeg fallback", cameraIndex);
-				camera.release();
-				open = false;
-			}
+		// On Linux with a known device path, use ffmpeg directly.
+		// OpenCV 2.4's v4l1compat interaction poisons the V4L2 device state,
+		// making it inaccessible to ffmpeg (and sometimes itself) afterwards.
+		if (devicePath != null && System.getProperty("os.name", "").toLowerCase().contains("linux")) {
+			logger.info("Linux detected with device path {}, using ffmpeg directly", devicePath);
+			open = openFfmpegFallback();
 		}
 
-		if (!open && devicePath != null) {
-			// Fall back to ffmpeg process-based capture
-			open = openFfmpegFallback();
+		if (!open) {
+			// Try OpenCV (works well on Windows/Mac, or Linux without device path)
+			open = camera.open(cameraIndex);
+
+			if (open) {
+				// Verify we can actually read a frame
+				final Mat testFrame = new Mat();
+				boolean canRead = false;
+				for (int i = 0; i < 3; i++) {
+					if (camera.read(testFrame) && testFrame.size().height > 0) {
+						canRead = true;
+						break;
+					}
+					try { Thread.sleep(100); } catch (InterruptedException ignored) {}
+				}
+				if (!canRead) {
+					logger.warn("OpenCV opened device {} but cannot read frames", cameraIndex);
+					camera.release();
+					open = false;
+				}
+			}
 		}
 
 		if (open) {
@@ -228,58 +235,66 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 		final int[][] resolutions = {{640, 480}, {320, 240}};
 
 		for (final int[] res : resolutions) {
-			try {
-				final ProcessBuilder pb = new ProcessBuilder(
-					"ffmpeg",
-					"-loglevel", "error",
-					"-f", "v4l2",
-					"-video_size", res[0] + "x" + res[1],
-					"-i", devicePath,
-					"-f", "rawvideo",
-					"-pix_fmt", "bgr24",
-					"-an",
-					"-"
-				);
-				pb.redirectErrorStream(false);
-				// Send ffmpeg's stderr to /dev/null to prevent buffer fill-up
-				pb.redirectError(new java.io.File("/dev/null"));
-				final Process proc = pb.start();
-
-				// Read a test frame to verify it works
-				final InputStream stream = proc.getInputStream();
-				final int frameSize = res[0] * res[1] * 3;
-				final byte[] testBuf = new byte[frameSize];
-				int offset = 0;
-				final long deadline = System.currentTimeMillis() + 5000;
-				while (offset < frameSize && System.currentTimeMillis() < deadline) {
-					final int read = stream.read(testBuf, offset, frameSize - offset);
-					if (read == -1) break;
-					offset += read;
+			// Retry up to 3 times — the webcam-capture discovery service may be
+			// holding the device briefly during background probing
+			for (int attempt = 0; attempt < 3; attempt++) {
+				if (attempt > 0) {
+					logger.info("Retrying ffmpeg for {} (attempt {})", devicePath, attempt + 1);
+					try { Thread.sleep(1000); } catch (InterruptedException ignored) {}
 				}
+				try {
+					final ProcessBuilder pb = new ProcessBuilder(
+						"ffmpeg",
+						"-loglevel", "error",
+						"-f", "v4l2",
+						"-video_size", res[0] + "x" + res[1],
+						"-i", devicePath,
+						"-f", "rawvideo",
+						"-pix_fmt", "bgr24",
+						"-an",
+						"-"
+					);
+					pb.redirectErrorStream(false);
+					// Send ffmpeg's stderr to /dev/null to prevent buffer fill-up
+					pb.redirectError(new java.io.File("/dev/null"));
+					final Process proc = pb.start();
 
-				if (offset == frameSize) {
-					ffmpegProcess = proc;
-					ffmpegStream = stream;
-					ffmpegWidth = res[0];
-					ffmpegHeight = res[1];
-					usingFfmpegFallback = true;
-					logger.info("ffmpeg fallback opened at {}x{} for {}", res[0], res[1], devicePath);
+					// Read a test frame to verify it works
+					final InputStream stream = proc.getInputStream();
+					final int frameSize = res[0] * res[1] * 3;
+					final byte[] testBuf = new byte[frameSize];
+					int offset = 0;
+					final long deadline = System.currentTimeMillis() + 5000;
+					while (offset < frameSize && System.currentTimeMillis() < deadline) {
+						final int read = stream.read(testBuf, offset, frameSize - offset);
+						if (read == -1) break;
+						offset += read;
+					}
 
-					// Ensure ffmpeg is killed when JVM exits
-					Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-						if (ffmpegProcess != null && ffmpegProcess.isAlive()) {
-							ffmpegProcess.destroyForcibly();
-						}
-					}));
+					if (offset == frameSize) {
+						ffmpegProcess = proc;
+						ffmpegStream = stream;
+						ffmpegWidth = res[0];
+						ffmpegHeight = res[1];
+						usingFfmpegFallback = true;
+						logger.info("ffmpeg fallback opened at {}x{} for {}", res[0], res[1], devicePath);
 
-					return true;
-				} else {
-					logger.warn("ffmpeg fallback could not read full frame at {}x{} (got {} of {} bytes)",
-						res[0], res[1], offset, frameSize);
-					proc.destroyForcibly();
+						// Ensure ffmpeg is killed when JVM exits
+						Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+							if (ffmpegProcess != null && ffmpegProcess.isAlive()) {
+								ffmpegProcess.destroyForcibly();
+							}
+						}));
+
+						return true;
+					} else {
+						logger.info("ffmpeg could not read full frame at {}x{} (got {} of {} bytes, attempt {})",
+							res[0], res[1], offset, frameSize, attempt + 1);
+						proc.destroyForcibly();
+					}
+				} catch (final Exception e) {
+					logger.error("ffmpeg fallback failed at {}x{}", res[0], res[1], e);
 				}
-			} catch (final Exception e) {
-				logger.error("ffmpeg fallback failed at {}x{}", res[0], res[1], e);
 			}
 		}
 

--- a/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
+++ b/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
@@ -132,9 +132,21 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 			if (sarxosWebcam == null || !sarxosWebcam.isOpen()) return null;
 			final BufferedImage img = sarxosWebcam.getImage();
 			if (img == null) return null;
+
+			// webcam-capture may return TYPE_CUSTOM images that don't
+			// convert correctly to Mat. Re-draw into a TYPE_3BYTE_BGR
+			// image to ensure the pixel layout matches what OpenCV expects.
+			final BufferedImage bgrImage;
+			if (img.getType() != BufferedImage.TYPE_3BYTE_BGR) {
+				bgrImage = new BufferedImage(img.getWidth(), img.getHeight(), BufferedImage.TYPE_3BYTE_BGR);
+				bgrImage.getGraphics().drawImage(img, 0, 0, null);
+			} else {
+				bgrImage = img;
+			}
+
 			final long currentFrameTimestamp = System.currentTimeMillis();
 			frameCount++;
-			return new Frame(img, currentFrameTimestamp);
+			return new Frame(bgrImage, currentFrameTimestamp);
 		} catch (final Exception e) {
 			return null;
 		}

--- a/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
+++ b/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
@@ -48,6 +48,7 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	private int cameraIndex = -1;
 	private int discoveryIndex = -1;
+	private String cameraName;
 	private final VideoCapture camera;
 
 	// Fallback: use webcam-capture directly when OpenCV can't handle the device
@@ -90,6 +91,7 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 		if (cameraIndex < 0) throw new IllegalArgumentException("Camera not found: " + cameraName);
 
 		camera = new VideoCapture();
+		this.cameraName = cameraName;
 		this.discoveryIndex = cameraIndex;
 		this.cameraIndex = resolveDeviceIndex(cameraName, cameraIndex);
 
@@ -99,6 +101,7 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 		if (cameraIndex < 0) throw new IllegalArgumentException("Camera not found: " + cameraName);
 
 		camera = new VideoCapture();
+		this.cameraName = cameraName;
 		this.discoveryIndex = cameraIndex;
 		this.cameraIndex = resolveDeviceIndex(cameraName, cameraIndex);
 
@@ -187,6 +190,29 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 			if (idx >= 0 && idx < webcams.size()) {
 				sarxosWebcam = webcams.get(idx);
 				try {
+					// Request a usable resolution. The bridj-based native
+					// capture can segfault at large sizes (e.g. 640x480) on
+					// some devices, so pick the largest size that doesn't
+					// exceed 320x240 — or fall back to the biggest available
+					// if all sizes are small.
+					final Dimension[] sizes = sarxosWebcam.getViewSizes();
+					if (sizes != null && sizes.length > 0) {
+						Dimension best = sizes[0];
+						Dimension bestSafe = null;
+						for (final Dimension d : sizes) {
+							if (d.width <= 320 && d.height <= 240) {
+								if (bestSafe == null || d.width * d.height > bestSafe.width * bestSafe.height) {
+									bestSafe = d;
+								}
+							}
+							if (d.width * d.height > best.width * best.height) {
+								best = d;
+							}
+						}
+						final Dimension chosen = bestSafe != null ? bestSafe : best;
+						sarxosWebcam.setViewSize(chosen);
+						logger.info("Set webcam-capture resolution to {}x{}", chosen.width, chosen.height);
+					}
 					sarxosWebcam.open();
 					if (sarxosWebcam.isOpen()) {
 						usingSarxosFallback = true;
@@ -248,6 +274,7 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	@Override
 	public String getName() {
+		if (cameraName != null) return cameraName;
 		return Webcam.getWebcams().get(discoveryIndex >= 0 ? discoveryIndex : cameraIndex).getName();
 	}
 

--- a/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
+++ b/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
@@ -20,12 +20,15 @@ package com.shootoff.camera.cameratypes;
 
 import java.awt.Dimension;
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.opencv.core.CvType;
 import org.opencv.core.Mat;
 import org.opencv.highgui.Highgui;
 import org.opencv.highgui.VideoCapture;
@@ -51,9 +54,13 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 	private String cameraName;
 	private final VideoCapture camera;
 
-	// Fallback: use webcam-capture directly when OpenCV can't handle the device
-	private Webcam sarxosWebcam = null;
-	private boolean usingSarxosFallback = false;
+	// Fallback: use ffmpeg process when OpenCV can't handle the device
+	private Process ffmpegProcess = null;
+	private InputStream ffmpegStream = null;
+	private boolean usingFfmpegFallback = false;
+	private int ffmpegWidth = 640;
+	private int ffmpegHeight = 480;
+	private String devicePath = null;
 
 	private final AtomicBoolean closing = new AtomicBoolean(false);
 	private static final Pattern DEV_VIDEO_PATTERN = Pattern.compile("/dev/video(\\d+)");
@@ -70,6 +77,12 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 			return deviceIndex;
 		}
 		return fallbackIndex;
+	}
+
+	private static String extractDevicePath(String cameraName) {
+		final Matcher m = DEV_VIDEO_PATTERN.matcher(cameraName);
+		if (m.find()) return m.group();
+		return null;
 	}
 
 	// For testing
@@ -94,7 +107,7 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 		this.cameraName = cameraName;
 		this.discoveryIndex = cameraIndex;
 		this.cameraIndex = resolveDeviceIndex(cameraName, cameraIndex);
-
+		this.devicePath = extractDevicePath(cameraName);
 	}
 
 	public SarxosCaptureCamera(final String cameraName, int cameraIndex) {
@@ -104,21 +117,19 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 		this.cameraName = cameraName;
 		this.discoveryIndex = cameraIndex;
 		this.cameraIndex = resolveDeviceIndex(cameraName, cameraIndex);
-
+		this.devicePath = extractDevicePath(cameraName);
 	}
 
 	@Override
 	public Frame getFrame() {
-		if (usingSarxosFallback) {
-			return getSarxosFrame();
+		if (usingFfmpegFallback) {
+			return getFfmpegFrame();
 		}
 
 		final Mat frame = new Mat();
 		try {
 			if (!isOpen() || !camera.read(frame) || frame.size().height == 0 || frame.size().width == 0) return null;
 		} catch (final Exception e) {
-			// Sometimes there is a race condition on closing the camera vs.
-			// read()
 			return null;
 		}
 
@@ -127,27 +138,29 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 		return new Frame(frame, currentFrameTimestamp);
 	}
 
-	private Frame getSarxosFrame() {
+	private Frame getFfmpegFrame() {
 		try {
-			if (sarxosWebcam == null || !sarxosWebcam.isOpen()) return null;
-			final BufferedImage img = sarxosWebcam.getImage();
-			if (img == null) return null;
-
-			// webcam-capture may return TYPE_CUSTOM images that don't
-			// convert correctly to Mat. Re-draw into a TYPE_3BYTE_BGR
-			// image to ensure the pixel layout matches what OpenCV expects.
-			final BufferedImage bgrImage;
-			if (img.getType() != BufferedImage.TYPE_3BYTE_BGR) {
-				bgrImage = new BufferedImage(img.getWidth(), img.getHeight(), BufferedImage.TYPE_3BYTE_BGR);
-				bgrImage.getGraphics().drawImage(img, 0, 0, null);
-			} else {
-				bgrImage = img;
+			if (ffmpegStream == null) return null;
+			final int frameSize = ffmpegWidth * ffmpegHeight * 3;
+			final byte[] buf = new byte[frameSize];
+			int offset = 0;
+			while (offset < frameSize) {
+				final int read = ffmpegStream.read(buf, offset, frameSize - offset);
+				if (read == -1) {
+					logger.warn("ffmpeg stream ended");
+					return null;
+				}
+				offset += read;
 			}
+
+			final Mat mat = new Mat(ffmpegHeight, ffmpegWidth, CvType.CV_8UC3);
+			mat.put(0, 0, buf);
 
 			final long currentFrameTimestamp = System.currentTimeMillis();
 			frameCount++;
-			return new Frame(bgrImage, currentFrameTimestamp);
+			return new Frame(mat, currentFrameTimestamp);
 		} catch (final Exception e) {
+			logger.error("Error reading ffmpeg frame", e);
 			return null;
 		}
 	}
@@ -176,8 +189,7 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 		boolean open = camera.open(cameraIndex);
 
 		if (open) {
-			// Verify we can actually read a frame — some devices open but
-			// return empty frames (e.g. when webcam-capture holds the device)
+			// Verify we can actually read a frame
 			final Mat testFrame = new Mat();
 			boolean canRead = false;
 			for (int i = 0; i < 3; i++) {
@@ -188,72 +200,85 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 				try { Thread.sleep(100); } catch (InterruptedException ignored) {}
 			}
 			if (!canRead) {
-				logger.warn("OpenCV opened device {} but cannot read frames, trying webcam-capture fallback", cameraIndex);
+				logger.warn("OpenCV opened device {} but cannot read frames, trying ffmpeg fallback", cameraIndex);
 				camera.release();
 				open = false;
 			}
 		}
 
-		if (!open) {
-			// Fall back to webcam-capture's own capture mechanism
-			logger.info("Attempting webcam-capture fallback for camera index {} (discovery {})", cameraIndex, discoveryIndex);
-			final int idx = discoveryIndex >= 0 ? discoveryIndex : cameraIndex;
-			final List<Webcam> webcams = Webcam.getWebcams();
-			if (idx >= 0 && idx < webcams.size()) {
-				sarxosWebcam = webcams.get(idx);
-				try {
-					// Request a usable resolution. The bridj-based native
-					// capture can segfault at large sizes (e.g. 640x480) on
-					// some devices, so pick the largest size that doesn't
-					// exceed 320x240 — or fall back to the biggest available
-					// if all sizes are small.
-					final Dimension[] sizes = sarxosWebcam.getViewSizes();
-					if (sizes != null && sizes.length > 0) {
-						Dimension best = sizes[0];
-						Dimension bestSafe = null;
-						for (final Dimension d : sizes) {
-							if (d.width <= 320 && d.height <= 240) {
-								if (bestSafe == null || d.width * d.height > bestSafe.width * bestSafe.height) {
-									bestSafe = d;
-								}
-							}
-							if (d.width * d.height > best.width * best.height) {
-								best = d;
-							}
-						}
-						final Dimension chosen = bestSafe != null ? bestSafe : best;
-						sarxosWebcam.setViewSize(chosen);
-						logger.info("Set webcam-capture resolution to {}x{}", chosen.width, chosen.height);
-					}
-					sarxosWebcam.open();
-					if (sarxosWebcam.isOpen()) {
-						usingSarxosFallback = true;
-						open = true;
-						logger.info("Successfully opened camera via webcam-capture fallback: {}", sarxosWebcam.getName());
-					}
-				} catch (final Exception e) {
-					logger.error("webcam-capture fallback also failed for camera", e);
-				}
-			}
+		if (!open && devicePath != null) {
+			// Fall back to ffmpeg process-based capture
+			open = openFfmpegFallback();
 		}
 
 		if (open) {
-			if (!usingSarxosFallback) {
-				// Set the max FPS to 60. If we don't set this it defaults
-				// to 30, which unnecessarily hampers higher end cameras
+			if (!usingFfmpegFallback) {
 				camera.set(5, 60);
 			}
-
 			CameraFactory.openCamerasAdd(this);
 		}
 
 		return open;
 	}
 
+	private boolean openFfmpegFallback() {
+		logger.info("Attempting ffmpeg fallback for {}", devicePath);
+
+		// Try 640x480 first, then 320x240
+		final int[][] resolutions = {{640, 480}, {320, 240}};
+
+		for (final int[] res : resolutions) {
+			try {
+				final ProcessBuilder pb = new ProcessBuilder(
+					"ffmpeg",
+					"-f", "v4l2",
+					"-video_size", res[0] + "x" + res[1],
+					"-i", devicePath,
+					"-f", "rawvideo",
+					"-pix_fmt", "bgr24",
+					"-an",
+					"-"
+				);
+				pb.redirectErrorStream(false);
+				final Process proc = pb.start();
+
+				// Read a test frame to verify it works
+				final InputStream stream = proc.getInputStream();
+				final int frameSize = res[0] * res[1] * 3;
+				final byte[] testBuf = new byte[frameSize];
+				int offset = 0;
+				final long deadline = System.currentTimeMillis() + 5000;
+				while (offset < frameSize && System.currentTimeMillis() < deadline) {
+					final int read = stream.read(testBuf, offset, frameSize - offset);
+					if (read == -1) break;
+					offset += read;
+				}
+
+				if (offset == frameSize) {
+					ffmpegProcess = proc;
+					ffmpegStream = stream;
+					ffmpegWidth = res[0];
+					ffmpegHeight = res[1];
+					usingFfmpegFallback = true;
+					logger.info("ffmpeg fallback opened at {}x{} for {}", res[0], res[1], devicePath);
+					return true;
+				} else {
+					logger.warn("ffmpeg fallback could not read full frame at {}x{} (got {} of {} bytes)",
+						res[0], res[1], offset, frameSize);
+					proc.destroyForcibly();
+				}
+			} catch (final Exception e) {
+				logger.error("ffmpeg fallback failed at {}x{}", res[0], res[1], e);
+			}
+		}
+
+		return false;
+	}
+
 	@Override
 	public boolean isOpen() {
-		if (usingSarxosFallback) {
-			return sarxosWebcam != null && sarxosWebcam.isOpen();
+		if (usingFfmpegFallback) {
+			return ffmpegProcess != null && ffmpegProcess.isAlive();
 		}
 		return camera.isOpened();
 	}
@@ -265,11 +290,15 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 		if (isOpen() && !closing.get()) {
 			closing.set(true);
-			if (!usingSarxosFallback) {
+			if (usingFfmpegFallback) {
+				if (ffmpegProcess != null) {
+					ffmpegProcess.destroyForcibly();
+					ffmpegProcess = null;
+					ffmpegStream = null;
+				}
+			} else {
 				resetExposure();
 				camera.release();
-			} else if (sarxosWebcam != null) {
-				sarxosWebcam.close();
 			}
 
 			CameraFactory.openCamerasRemove(this);
@@ -292,9 +321,7 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	@Override
 	public void setViewSize(final Dimension size) {
-		if (usingSarxosFallback) {
-			if (sarxosWebcam != null) sarxosWebcam.setViewSize(size);
-		} else {
+		if (!usingFfmpegFallback) {
 			camera.set(Highgui.CV_CAP_PROP_FRAME_WIDTH, size.getWidth());
 			camera.set(Highgui.CV_CAP_PROP_FRAME_HEIGHT, size.getHeight());
 		}
@@ -302,15 +329,15 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	@Override
 	public Dimension getViewSize() {
-		if (usingSarxosFallback && sarxosWebcam != null) {
-			return sarxosWebcam.getViewSize();
+		if (usingFfmpegFallback) {
+			return new Dimension(ffmpegWidth, ffmpegHeight);
 		}
 		return new Dimension((int) camera.get(Highgui.CV_CAP_PROP_FRAME_WIDTH),
 				(int) camera.get(Highgui.CV_CAP_PROP_FRAME_HEIGHT));
 	}
 
 	public void launchCameraSettings() {
-		if (!usingSarxosFallback) camera.set(Highgui.CV_CAP_PROP_SETTINGS, 1);
+		if (!usingFfmpegFallback) camera.set(Highgui.CV_CAP_PROP_SETTINGS, 1);
 	}
 
 	@Override
@@ -349,10 +376,8 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	@Override
 	public boolean supportsExposureAdjustment() {
-		if (usingSarxosFallback) return false;
+		if (usingFfmpegFallback) return false;
 
-		// If we already verified that it works,
-		// we have an origExposure value set
 		if (origExposure.isPresent()) return true;
 
 		final double exp = camera.get(CV_CAP_PROP_EXPOSURE);
@@ -375,17 +400,8 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	@Override
 	public boolean decreaseExposure() {
-		if (usingSarxosFallback) return false;
+		if (usingFfmpegFallback) return false;
 
-		// Logic:
-		// If camera exposure is positive, decrease towards zero
-		// If camera exposure is negative and between -9.9 and 0, increase
-		// towards zero (Logitech c270)
-		// If camera exposure is negative and less than -10, decrease away from
-		// zero (oCam)
-
-		// In any case, if exposure doesn't change in the same direction when we
-		// change it, fail out.
 		final double curExp = camera.get(CV_CAP_PROP_EXPOSURE);
 		final double newExp;
 		if (curExp <= -10.0) {
@@ -396,7 +412,6 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 		if (logger.isTraceEnabled()) logger.trace("curExp[ {} newExp {}", curExp, newExp);
 
-		// If they don't have the same sign, ABORT
 		if (!((curExp < 0) == (newExp < 0)) || Math.abs(curExp - newExp) < .001f) return false;
 
 		camera.set(CV_CAP_PROP_EXPOSURE, newExp);
@@ -412,7 +427,7 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	@Override
 	public void resetExposure() {
-		if (!usingSarxosFallback && origExposure.isPresent()) camera.set(CV_CAP_PROP_EXPOSURE, origExposure.get());
+		if (!usingFfmpegFallback && origExposure.isPresent()) camera.set(CV_CAP_PROP_EXPOSURE, origExposure.get());
 	}
 
 	@Override

--- a/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
+++ b/src/main/java/com/shootoff/camera/cameratypes/SarxosCaptureCamera.java
@@ -1,17 +1,17 @@
 /*
  * ShootOFF - Software for Laser Dry Fire Training
  * Copyright (C) 2016 phrack
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,6 +23,8 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.opencv.core.Mat;
 import org.opencv.highgui.Highgui;
@@ -45,9 +47,29 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 	public static final int CV_CAP_PROP_EXPOSURE = 15;
 
 	private int cameraIndex = -1;
+	private int discoveryIndex = -1;
 	private final VideoCapture camera;
 
+	// Fallback: use webcam-capture directly when OpenCV can't handle the device
+	private Webcam sarxosWebcam = null;
+	private boolean usingSarxosFallback = false;
+
 	private final AtomicBoolean closing = new AtomicBoolean(false);
+	private static final Pattern DEV_VIDEO_PATTERN = Pattern.compile("/dev/video(\\d+)");
+
+	private static int resolveDeviceIndex(String cameraName, int fallbackIndex) {
+		final Matcher m = DEV_VIDEO_PATTERN.matcher(cameraName);
+		if (m.find()) {
+			final int deviceIndex = Integer.parseInt(m.group(1));
+			if (deviceIndex != fallbackIndex) {
+				LoggerFactory.getLogger(SarxosCaptureCamera.class).info(
+					"Camera '{}': using /dev/video{} instead of discovery index {}",
+					cameraName, deviceIndex, fallbackIndex);
+			}
+			return deviceIndex;
+		}
+		return fallbackIndex;
+	}
 
 	// For testing
 	protected SarxosCaptureCamera() {
@@ -68,7 +90,8 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 		if (cameraIndex < 0) throw new IllegalArgumentException("Camera not found: " + cameraName);
 
 		camera = new VideoCapture();
-		this.cameraIndex = cameraIndex;
+		this.discoveryIndex = cameraIndex;
+		this.cameraIndex = resolveDeviceIndex(cameraName, cameraIndex);
 
 	}
 
@@ -76,12 +99,17 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 		if (cameraIndex < 0) throw new IllegalArgumentException("Camera not found: " + cameraName);
 
 		camera = new VideoCapture();
-		this.cameraIndex = cameraIndex;
+		this.discoveryIndex = cameraIndex;
+		this.cameraIndex = resolveDeviceIndex(cameraName, cameraIndex);
 
 	}
 
 	@Override
 	public Frame getFrame() {
+		if (usingSarxosFallback) {
+			return getSarxosFrame();
+		}
+
 		final Mat frame = new Mat();
 		try {
 			if (!isOpen() || !camera.read(frame) || frame.size().height == 0 || frame.size().width == 0) return null;
@@ -94,6 +122,19 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 		final long currentFrameTimestamp = System.currentTimeMillis();
 		frameCount++;
 		return new Frame(frame, currentFrameTimestamp);
+	}
+
+	private Frame getSarxosFrame() {
+		try {
+			if (sarxosWebcam == null || !sarxosWebcam.isOpen()) return null;
+			final BufferedImage img = sarxosWebcam.getImage();
+			if (img == null) return null;
+			final long currentFrameTimestamp = System.currentTimeMillis();
+			frameCount++;
+			return new Frame(img, currentFrameTimestamp);
+		} catch (final Exception e) {
+			return null;
+		}
 	}
 
 	@Override
@@ -116,12 +157,54 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 		closing.set(false);
 
-		final boolean open = camera.open(cameraIndex);
+		// Try OpenCV first
+		boolean open = camera.open(cameraIndex);
 
 		if (open) {
-			// Set the max FPS to 60. If we don't set this it defaults
-			// to 30, which unnecessarily hampers higher end cameras
-			camera.set(5, 60);
+			// Verify we can actually read a frame — some devices open but
+			// return empty frames (e.g. when webcam-capture holds the device)
+			final Mat testFrame = new Mat();
+			boolean canRead = false;
+			for (int i = 0; i < 3; i++) {
+				if (camera.read(testFrame) && testFrame.size().height > 0) {
+					canRead = true;
+					break;
+				}
+				try { Thread.sleep(100); } catch (InterruptedException ignored) {}
+			}
+			if (!canRead) {
+				logger.warn("OpenCV opened device {} but cannot read frames, trying webcam-capture fallback", cameraIndex);
+				camera.release();
+				open = false;
+			}
+		}
+
+		if (!open) {
+			// Fall back to webcam-capture's own capture mechanism
+			logger.info("Attempting webcam-capture fallback for camera index {} (discovery {})", cameraIndex, discoveryIndex);
+			final int idx = discoveryIndex >= 0 ? discoveryIndex : cameraIndex;
+			final List<Webcam> webcams = Webcam.getWebcams();
+			if (idx >= 0 && idx < webcams.size()) {
+				sarxosWebcam = webcams.get(idx);
+				try {
+					sarxosWebcam.open();
+					if (sarxosWebcam.isOpen()) {
+						usingSarxosFallback = true;
+						open = true;
+						logger.info("Successfully opened camera via webcam-capture fallback: {}", sarxosWebcam.getName());
+					}
+				} catch (final Exception e) {
+					logger.error("webcam-capture fallback also failed for camera", e);
+				}
+			}
+		}
+
+		if (open) {
+			if (!usingSarxosFallback) {
+				// Set the max FPS to 60. If we don't set this it defaults
+				// to 30, which unnecessarily hampers higher end cameras
+				camera.set(5, 60);
+			}
 
 			CameraFactory.openCamerasAdd(this);
 		}
@@ -131,6 +214,9 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	@Override
 	public boolean isOpen() {
+		if (usingSarxosFallback) {
+			return sarxosWebcam != null && sarxosWebcam.isOpen();
+		}
 		return camera.isOpened();
 	}
 
@@ -141,12 +227,16 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 		if (isOpen() && !closing.get()) {
 			closing.set(true);
-			resetExposure();
-			camera.release();
+			if (!usingSarxosFallback) {
+				resetExposure();
+				camera.release();
+			} else if (sarxosWebcam != null) {
+				sarxosWebcam.close();
+			}
 
 			CameraFactory.openCamerasRemove(this);
 			if (cameraEventListener.isPresent()) cameraEventListener.get().cameraClosed();
-			
+
 		} else if (isOpen() && closing.get()) {
 			return;
 		} else if (!isOpen()) {
@@ -158,23 +248,30 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	@Override
 	public String getName() {
-		return Webcam.getWebcams().get(cameraIndex).getName();
+		return Webcam.getWebcams().get(discoveryIndex >= 0 ? discoveryIndex : cameraIndex).getName();
 	}
 
 	@Override
 	public void setViewSize(final Dimension size) {
-		camera.set(Highgui.CV_CAP_PROP_FRAME_WIDTH, size.getWidth());
-		camera.set(Highgui.CV_CAP_PROP_FRAME_HEIGHT, size.getHeight());
+		if (usingSarxosFallback) {
+			if (sarxosWebcam != null) sarxosWebcam.setViewSize(size);
+		} else {
+			camera.set(Highgui.CV_CAP_PROP_FRAME_WIDTH, size.getWidth());
+			camera.set(Highgui.CV_CAP_PROP_FRAME_HEIGHT, size.getHeight());
+		}
 	}
 
 	@Override
 	public Dimension getViewSize() {
+		if (usingSarxosFallback && sarxosWebcam != null) {
+			return sarxosWebcam.getViewSize();
+		}
 		return new Dimension((int) camera.get(Highgui.CV_CAP_PROP_FRAME_WIDTH),
 				(int) camera.get(Highgui.CV_CAP_PROP_FRAME_HEIGHT));
 	}
 
 	public void launchCameraSettings() {
-		camera.set(Highgui.CV_CAP_PROP_SETTINGS, 1);
+		if (!usingSarxosFallback) camera.set(Highgui.CV_CAP_PROP_SETTINGS, 1);
 	}
 
 	@Override
@@ -213,6 +310,8 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	@Override
 	public boolean supportsExposureAdjustment() {
+		if (usingSarxosFallback) return false;
+
 		// If we already verified that it works,
 		// we have an origExposure value set
 		if (origExposure.isPresent()) return true;
@@ -237,6 +336,8 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	@Override
 	public boolean decreaseExposure() {
+		if (usingSarxosFallback) return false;
+
 		// Logic:
 		// If camera exposure is positive, decrease towards zero
 		// If camera exposure is negative and between -9.9 and 0, increase
@@ -272,7 +373,7 @@ public class SarxosCaptureCamera extends CalculatedFPSCamera {
 
 	@Override
 	public void resetExposure() {
-		if (origExposure.isPresent()) camera.set(CV_CAP_PROP_EXPOSURE, origExposure.get());
+		if (!usingSarxosFallback && origExposure.isPresent()) camera.set(CV_CAP_PROP_EXPOSURE, origExposure.get());
 	}
 
 	@Override

--- a/src/main/java/com/shootoff/camera/shotdetection/JavaShotDetector.java
+++ b/src/main/java/com/shootoff/camera/shotdetection/JavaShotDetector.java
@@ -71,7 +71,9 @@ public final class JavaShotDetector extends FrameProcessingShotDetector {
 	// Individual pixel threshold
 	private final static int MAXIMUM_LUM_VALUE = 65025;
 	private final static int EXCESSIVE_BRIGHTNESS_THRESHOLD = (int) (.96 * MAXIMUM_LUM_VALUE);
-	private final static int MINIMUM_BRIGHTNESS_INCREASE = (int) (.117 * MAXIMUM_LUM_VALUE);;
+	private final static int DEFAULT_MINIMUM_BRIGHTNESS_INCREASE = (int) (.117 * MAXIMUM_LUM_VALUE);
+	private int minimumBrightnessIncrease = DEFAULT_MINIMUM_BRIGHTNESS_INCREASE;
+	private int dynamicThresholdDivisor = 4; // higher = less aggressive dynamic filtering
 
 	// Aggregate # of pixel threshold
 	private int BRIGHTNESS_WARNING_AVG_THRESHOLD;
@@ -112,6 +114,20 @@ public final class JavaShotDetector extends FrameProcessingShotDetector {
 
 		this.cameraManager = cameraManager;
 
+		// Apply detection sensitivity from config (1-10, default 5)
+		// Sensitivity 1 = 20% of max lum (least sensitive)
+		// Sensitivity 5 = 11.7% (original default)
+		// Sensitivity 10 = 1% (most sensitive)
+		final Configuration cfg = Configuration.getConfig();
+		if (cfg != null) {
+			final int sensitivity = cfg.getDetectionSensitivity();
+			// 1->0.20, 5->0.117, 10->0.01
+			final double factor = Math.max(0.01, 0.222 - (sensitivity * 0.0213));
+			minimumBrightnessIncrease = (int) (factor * MAXIMUM_LUM_VALUE);
+			// At high sensitivity, relax dynamic threshold slightly
+			dynamicThresholdDivisor = sensitivity >= 8 ? 5 : 4;
+		}
+
 		setFrameSize(cameraManager.getFeedWidth(), cameraManager.getFeedHeight());
 
 		pixelClusterManager = new PixelClusterManager(cameraManager.getFeedWidth(), cameraManager.getFeedHeight());
@@ -132,9 +148,16 @@ public final class JavaShotDetector extends FrameProcessingShotDetector {
 
 		final double frameSize = width * height;
 
-		MOTION_WARNING_AVG_THRESHOLD = (int) (frameSize * .000395);
-		MOTION_WARNING_THRESHOLD_PIXELS = (int) (frameSize * 0.00195);
-		MAXIMUM_THRESHOLD_PIXELS_FOR_MOTION_AVG = (int) (frameSize * 0.00195);
+		// Scale motion thresholds with detection sensitivity — higher sensitivity
+		// means more pixels pass the brightness threshold, so we need to tolerate
+		// more threshold pixels before calling it "excessive motion"
+		final Configuration motionCfg = Configuration.getConfig();
+		final int sens = (motionCfg != null) ? motionCfg.getDetectionSensitivity() : 5;
+		// sensitivity 5 -> 1x (original), 10 -> 4x
+		final double motionScale = 1.0 + (Math.max(0, sens - 5) * 0.6);
+		MOTION_WARNING_AVG_THRESHOLD = (int) (frameSize * .000395 * motionScale);
+		MOTION_WARNING_THRESHOLD_PIXELS = (int) (frameSize * 0.00195 * motionScale);
+		MAXIMUM_THRESHOLD_PIXELS_FOR_MOTION_AVG = (int) (frameSize * 0.00195 * motionScale);
 
 		// Aggregate # of pixel threshold
 		BRIGHTNESS_WARNING_AVG_THRESHOLD = (int) (frameSize * .000325);
@@ -187,10 +210,9 @@ public final class JavaShotDetector extends FrameProcessingShotDetector {
 	private boolean pixelAboveThreshold(int currentLum, int lumsMovingAverage) {
 		final int increase = (currentLum - lumsMovingAverage);
 
-		if (increase < MINIMUM_BRIGHTNESS_INCREASE) return false;
+		if (increase < minimumBrightnessIncrease) return false;
 
-		// (var >> 2) equivalent to (var / 4)
-		final int threshold = (MAXIMUM_LUM_VALUE - lumsMovingAverage) >> 2;
+		final int threshold = (MAXIMUM_LUM_VALUE - lumsMovingAverage) / dynamicThresholdDivisor;
 
 		final int dynamic_increase = (int) ((MAXIMUM_LUM_VALUE - threshold)
 				* ((double) avgThresholdPixels / (double) MAXIMUM_THRESHOLD_PIXELS_FOR_AVG));

--- a/src/main/java/com/shootoff/camera/shotdetection/PixelClusterManager.java
+++ b/src/main/java/com/shootoff/camera/shotdetection/PixelClusterManager.java
@@ -179,9 +179,22 @@ public class PixelClusterManager {
 					shotHeight, shotRatio, minX, minY, maxX, maxY);
 
 			if ((shotWidth + shotHeight) > SMALL_SHOT_THRESHOLD
-					&& (shotRatio < MINIMUM_SHOT_RATIO || shotRatio > MAXIMUM_SHOT_RATIO))
+					&& (shotRatio < MINIMUM_SHOT_RATIO || shotRatio > MAXIMUM_SHOT_RATIO)) {
+				// Cluster is elongated (e.g. laser streak from recoil).
+				// Use the brightest pixel as the shot origin instead of discarding.
+				final PixelCluster streakShot = extractBrightestSubCluster(cluster, minimumShotDimension);
+				if (streakShot != null) {
+					clusters.add(streakShot);
+				}
 				continue;
-			else if (shotRatio < MINIMUM_SHOT_RATIO_SMALL || shotRatio > MAXIMUM_SHOT_RATIO_SMALL) continue;
+			}
+			else if (shotRatio < MINIMUM_SHOT_RATIO_SMALL || shotRatio > MAXIMUM_SHOT_RATIO_SMALL) {
+				final PixelCluster streakShot = extractBrightestSubCluster(cluster, minimumShotDimension);
+				if (streakShot != null) {
+					clusters.add(streakShot);
+				}
+				continue;
+			}
 
 			final double r = (double) (shotWidth + shotHeight) / 4.0f;
 			final double circleArea = Math.PI * r * r;
@@ -190,7 +203,14 @@ public class PixelClusterManager {
 			if (logger.isTraceEnabled()) logger.trace("Cluster {}: density {} {} - {} {} - {}", i, shotWidth,
 					shotHeight, circleArea, cluster.size(), density);
 
-			if (density < MINIMUM_DENSITY) continue;
+			if (density < MINIMUM_DENSITY) {
+				// Low density may indicate a streak — try to extract the impact point
+				final PixelCluster streakShot = extractBrightestSubCluster(cluster, minimumShotDimension);
+				if (streakShot != null) {
+					clusters.add(streakShot);
+				}
+				continue;
+			}
 
 			cluster.centerPixelX = averageX;
 			cluster.centerPixelY = averageY;
@@ -202,5 +222,62 @@ public class PixelClusterManager {
 			logger.trace("---- Detected {} shots from {} regions ------", clusters.size(), numberOfRegions + 1);
 
 		return clusters;
+	}
+
+	/**
+	 * For elongated clusters (laser streaks from recoil), find the brightest
+	 * pixel — the initial impact point before recoil dragged the laser — and
+	 * build a small sub-cluster around it.
+	 */
+	private PixelCluster extractBrightestSubCluster(PixelCluster cluster, int minimumShotDimension) {
+		if (cluster.size() < minimumShotDimension) return null;
+
+		// Find the brightest pixel (highest currentLum)
+		Pixel brightest = null;
+		int maxLum = -1;
+		for (final Pixel p : cluster) {
+			if (p.getCurrentLum() > maxLum) {
+				maxLum = p.getCurrentLum();
+				brightest = p;
+			}
+		}
+
+		if (brightest == null) return null;
+
+		// Collect nearby pixels within a small radius of the brightest point
+		final PixelCluster subCluster = new PixelCluster();
+		final int radius = 5;
+		for (final Pixel p : cluster) {
+			final int dx = p.x - brightest.x;
+			final int dy = p.y - brightest.y;
+			if (dx * dx + dy * dy <= radius * radius) {
+				subCluster.add(p);
+			}
+		}
+
+		if (subCluster.size() < minimumShotDimension) {
+			// Not enough pixels nearby — just use the brightest pixel location
+			subCluster.clear();
+			subCluster.add(brightest);
+		}
+
+		// Compute center weighted by connectedness
+		double weightedX = 0, weightedY = 0, totalWeight = 0;
+		for (final Pixel p : subCluster) {
+			final int weight = Math.max(1, p.getConnectedness());
+			weightedX += p.x * weight;
+			weightedY += p.y * weight;
+			totalWeight += weight;
+		}
+		subCluster.centerPixelX = weightedX / totalWeight;
+		subCluster.centerPixelY = weightedY / totalWeight;
+
+		if (logger.isTraceEnabled()) {
+			logger.trace("Streak detected: {} pixels, brightest at ({},{}), sub-cluster {} pixels at ({},{})",
+				cluster.size(), brightest.x, brightest.y,
+				subCluster.size(), subCluster.centerPixelX, subCluster.centerPixelY);
+		}
+
+		return subCluster;
 	}
 }

--- a/src/main/java/com/shootoff/config/Configuration.java
+++ b/src/main/java/com/shootoff/config/Configuration.java
@@ -290,7 +290,7 @@ public class Configuration {
 			final List<String> webcamInternalNames = new ArrayList<>();
 
 			for (final String nameString : prop.getProperty(WEBCAMS_PROP).split(",")) {
-				final String[] names = nameString.split(":");
+				final String[] names = nameString.split(":", 2);
 				if (names.length > 1) {
 					webcamNames.add(names[0].replaceAll("//`", ":"));
 					webcamInternalNames.add(names[1].replaceAll("//`", ":"));

--- a/src/main/java/com/shootoff/config/Configuration.java
+++ b/src/main/java/com/shootoff/config/Configuration.java
@@ -88,6 +88,7 @@ public class Configuration {
 	private static final String WEBCAMS_PROP = "shootoff.webcams";
 	private static final String RECORDING_WEBCAMS_PROP = WEBCAMS_PROP + ".recording";
 	private static final String MARKER_RADIUS_PROP = "shootoff.markerradius";
+	private static final String DETECTION_SENSITIVITY_PROP = "shootoff.detectionsensitivity";
 	private static final String IGNORE_LASER_COLOR_PROP = "shootoff.ignorelasercolor";
 	private static final String USE_RED_LASER_SOUND_PROP = "shootoff.redlasersound.use";
 	private static final String RED_LASER_SOUND_PROP = "shootoff.redlasersound";
@@ -133,6 +134,7 @@ public class Configuration {
 	private final Map<String, String> ipcamCredentials = new HashMap<>();
 	private final Map<String, Camera> webcams = new HashMap<>();
 	private int markerRadius = 4;
+	private int detectionSensitivity = 5; // 1 (least sensitive) to 10 (most sensitive), default 5
 	private boolean ignoreLaserColor = false;
 	private String ignoreLaserColorName = "None";
 	private boolean useRedLaserSound = false;
@@ -321,6 +323,10 @@ public class Configuration {
 			setMarkerRadius(Integer.parseInt(prop.getProperty(MARKER_RADIUS_PROP)));
 		}
 
+		if (prop.containsKey(DETECTION_SENSITIVITY_PROP)) {
+			setDetectionSensitivity(Integer.parseInt(prop.getProperty(DETECTION_SENSITIVITY_PROP)));
+		}
+
 		if (prop.containsKey(IGNORE_LASER_COLOR_PROP)) {
 			final String colorName = prop.getProperty(IGNORE_LASER_COLOR_PROP);
 
@@ -475,6 +481,7 @@ public class Configuration {
 		prop.setProperty(WEBCAMS_PROP, webcamList.toString());
 		prop.setProperty(RECORDING_WEBCAMS_PROP, recordingWebcamList.toString());
 		prop.setProperty(MARKER_RADIUS_PROP, String.valueOf(markerRadius));
+		prop.setProperty(DETECTION_SENSITIVITY_PROP, String.valueOf(detectionSensitivity));
 		prop.setProperty(IGNORE_LASER_COLOR_PROP, ignoreLaserColorName);
 		prop.setProperty(USE_RED_LASER_SOUND_PROP, String.valueOf(useRedLaserSound));
 		prop.setProperty(RED_LASER_SOUND_PROP, redLaserSound.getPath());
@@ -705,6 +712,14 @@ public class Configuration {
 
 	public void setMarkerRadius(int markRadius) {
 		markerRadius = markRadius;
+	}
+
+	public void setDetectionSensitivity(int sensitivity) {
+		detectionSensitivity = Math.max(1, Math.min(10, sensitivity));
+	}
+
+	public int getDetectionSensitivity() {
+		return detectionSensitivity;
 	}
 
 	public void setIgnoreLaserColor(boolean ignoreLaserColor) {

--- a/src/main/java/com/shootoff/gui/controller/PreferencesController.java
+++ b/src/main/java/com/shootoff/gui/controller/PreferencesController.java
@@ -76,6 +76,8 @@ CameraRenamedListener {
 	@FXML private ListView<String> webcamListView;
 	@FXML private Slider markerRadiusSlider;
 	@FXML private Label markerRadiusLabel;
+	@FXML private Slider detectionSensitivitySlider;
+	@FXML private Label detectionSensitivityLabel;
 	@FXML private ChoiceBox<String> ignoreLaserColorChoiceBox;
 	@FXML private CheckBox redLaserSoundCheckBox;
 	@FXML private TextField redLaserSoundTextField;
@@ -136,6 +138,7 @@ CameraRenamedListener {
 		webcamListView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 
 		linkSliderToLabel(markerRadiusSlider, markerRadiusLabel);
+		linkSliderToLabel(detectionSensitivitySlider, detectionSensitivityLabel);
 		linkSliderToLabel(virtualMagazineSlider, virtualMagazineLabel);
 		linkSliderToLabel(malfunctionsSlider, malfunctionsLabel);
 
@@ -156,6 +159,7 @@ CameraRenamedListener {
 		webcamListView.setItems(cameras);
 
 		markerRadiusSlider.setValue(config.getMarkerRadius());
+		detectionSensitivitySlider.setValue(config.getDetectionSensitivity());
 		ignoreLaserColorChoiceBox.setValue(config.getIgnoreLaserColorName());
 		redLaserSoundCheckBox.setSelected(config.useRedLaserSound());
 		redLaserSoundTextField.setText(config.getRedLaserSound().getPath());
@@ -414,6 +418,7 @@ CameraRenamedListener {
 		config.setWebcams(configuredNames, configuredCameras);
 		config.setRecordingCameras(recordingCameras);
 		config.setMarkerRadius((int) markerRadiusSlider.getValue());
+		config.setDetectionSensitivity((int) detectionSensitivitySlider.getValue());
 		config.setIgnoreLaserColor(!ignoreLaserColorChoiceBox.getValue().equals("None"));
 		config.setIgnoreLaserColorName(ignoreLaserColorChoiceBox.getValue());
 		config.setUseRedLaserSound(redLaserSoundCheckBox.isSelected());

--- a/src/main/java/com/shootoff/gui/controller/ShootOFFController.java
+++ b/src/main/java/com/shootoff/gui/controller/ShootOFFController.java
@@ -498,8 +498,27 @@ public class ShootOFFController implements CameraConfigListener, CameraErrorView
 
 		final Tab cameraTab = new Tab(webcamName);
 		final Group cameraCanvasGroup = new Group();
-		// 640 x 480
-		cameraTab.setContent(new AnchorPane(cameraCanvasGroup));
+		final AnchorPane cameraPane = new AnchorPane(cameraCanvasGroup);
+		cameraTab.setContent(cameraPane);
+
+		// Scale the canvas group to fill available tab space while preserving
+		// the 4:3 aspect ratio. Coordinates stay at 640x480 internally.
+		final double baseWidth = config.getDisplayWidth();
+		final double baseHeight = config.getDisplayHeight();
+		final javafx.scene.transform.Scale scaleTransform = new javafx.scene.transform.Scale(1, 1);
+		cameraCanvasGroup.getTransforms().add(scaleTransform);
+
+		final Runnable updateScale = () -> {
+			final double paneW = cameraPane.getWidth();
+			final double paneH = cameraPane.getHeight();
+			if (paneW > 0 && paneH > 0) {
+				final double scale = Math.min(paneW / baseWidth, paneH / baseHeight);
+				scaleTransform.setX(scale);
+				scaleTransform.setY(scale);
+			}
+		};
+		cameraPane.widthProperty().addListener((obs, oldVal, newVal) -> updateScale.run());
+		cameraPane.heightProperty().addListener((obs, oldVal, newVal) -> updateScale.run());
 
 		final CanvasManager canvasManager = new CanvasManager(cameraCanvasGroup, this, webcamName, shotEntries);
 		final Optional<CameraManager> cameraManagerOptional = camerasSupervisor.addCameraManager(cameraInterface, this,

--- a/src/main/java/com/shootoff/gui/pane/Slide.java
+++ b/src/main/java/com/shootoff/gui/pane/Slide.java
@@ -53,8 +53,8 @@ public abstract class Slide {
 		this.parentBody = parentBody;
 
 		final ImageView backImage = new ImageView(
-				new Image(Slide.class.getResourceAsStream("/images/back_button.png"), 60.0, 60.0, true, true));
-		final Button backButton = addSlideControlButton("", (Event) -> hide());
+				new Image(Slide.class.getResourceAsStream("/images/back_button.png"), 16.0, 16.0, true, true));
+		final Button backButton = addSlideControlButton("Back", (Event) -> hide());
 		backButton.setGraphic(backImage);
 	}
 

--- a/src/main/java/com/shootoff/plugins/ProjectorTrainingExerciseBase.java
+++ b/src/main/java/com/shootoff/plugins/ProjectorTrainingExerciseBase.java
@@ -383,4 +383,8 @@ public class ProjectorTrainingExerciseBase extends TrainingExerciseBase {
 
 		super.destroy();
 	}
+
+	protected ProjectorArenaPane getArenaPane() {
+		return arenaPane;
+	}
 }

--- a/src/main/java/com/shootoff/plugins/TrainingExerciseBase.java
+++ b/src/main/java/com/shootoff/plugins/TrainingExerciseBase.java
@@ -39,6 +39,7 @@ import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.SourceDataLine;
 import javax.sound.sampled.UnsupportedAudioFileException;
 
+import javafx.scene.layout.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,10 +65,6 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumn.CellDataFeatures;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
-import javafx.scene.layout.ColumnConstraints;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.Pane;
-import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.util.Callback;
 
@@ -169,10 +166,8 @@ public abstract class TrainingExerciseBase {
 			getColumnConstraints().add(new ColumnConstraints(100));
 			setVgap(5);
 
-			final Label instructionsLabel = new Label("Set interval within which a beep will sound\n"
-					+ "to signal the start of a round.\nDefault: A round starts after a random wait\n"
-					+ "between 4 and 8 seconds in length.\n");
-			instructionsLabel.setPrefSize(300, 77);
+			final Label instructionsLabel = new Label("Set interval within which a beep will sound to signal the start of a round.\n");
+			instructionsLabel.setPrefSize(Region.USE_COMPUTED_SIZE, Region.USE_COMPUTED_SIZE);
 
 			this.add(instructionsLabel, 0, 0, 2, 3);
 			addRow(3, new Label("Min (s)"));

--- a/src/main/resources/com/shootoff/gui/Preferences.fxml
+++ b/src/main/resources/com/shootoff/gui/Preferences.fxml
@@ -48,31 +48,35 @@
                         <ColumnConstraints hgrow="SOMETIMES" percentWidth="15.0" />
                      </columnConstraints>
                      <rowConstraints>
-                        <RowConstraints percentHeight="17.0" vgrow="SOMETIMES" />
-                        <RowConstraints percentHeight="17.0" vgrow="SOMETIMES" />
-                        <RowConstraints percentHeight="17.0" vgrow="SOMETIMES" />
-                        <RowConstraints percentHeight="17.0" vgrow="SOMETIMES" />
-                        <RowConstraints percentHeight="17.0" vgrow="SOMETIMES" />
-                        <RowConstraints percentHeight="17.0" vgrow="SOMETIMES" />
+                        <RowConstraints percentHeight="14.0" vgrow="SOMETIMES" />
+                        <RowConstraints percentHeight="14.0" vgrow="SOMETIMES" />
+                        <RowConstraints percentHeight="14.0" vgrow="SOMETIMES" />
+                        <RowConstraints percentHeight="14.0" vgrow="SOMETIMES" />
+                        <RowConstraints percentHeight="14.0" vgrow="SOMETIMES" />
+                        <RowConstraints percentHeight="14.0" vgrow="SOMETIMES" />
+                        <RowConstraints percentHeight="14.0" vgrow="SOMETIMES" />
                      </rowConstraints>
                      <children>
                         <Label text="Marker Radius:" GridPane.rowIndex="0" />
                         <Label fx:id="markerRadiusLabel" maxWidth="55.0" minWidth="55.0" text="0" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="0" />
                         <Slider fx:id="markerRadiusSlider" blockIncrement="1.0" majorTickUnit="9.0" max="20.0" min="1.0" minorTickCount="4" showTickLabels="true" showTickMarks="true" GridPane.columnIndex="2" GridPane.rowIndex="0" />
-                        <Label text="Ignore Laser Color:" GridPane.rowIndex="1" />
-                        <CheckBox fx:id="virtualMagazineCheckBox" mnemonicParsing="false" onAction="#virtualMagazineCheckBoxClicked" text="Virtual Magazine:" GridPane.rowIndex="4" />
-                        <CheckBox fx:id="malfunctionsCheckBox" mnemonicParsing="false" onAction="#malfunctionsCheckBoxClicked" text="Inject Malfunctions (%):" GridPane.rowIndex="5" />                
-                        <Slider fx:id="virtualMagazineSlider" blockIncrement="1.0" disable="true" majorTickUnit="5.0" max="45.0" min="1.0" minorTickCount="2" showTickLabels="true" showTickMarks="true" value="1.0" GridPane.columnIndex="2" GridPane.rowIndex="4" />
-                        <Slider fx:id="malfunctionsSlider" disable="true" max="99.9" min="0.1" showTickLabels="true" showTickMarks="true" GridPane.columnIndex="2" GridPane.rowIndex="5" />
-                        <ChoiceBox fx:id="ignoreLaserColorChoiceBox" prefWidth="300.0" GridPane.columnIndex="2" GridPane.columnSpan="2147483647" GridPane.hgrow="ALWAYS" GridPane.rowIndex="1" />
-                        <Label fx:id="virtualMagazineLabel" maxWidth="55.0" minWidth="55.0" text="0" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="4" />
-                        <Label fx:id="malfunctionsLabel" maxWidth="55.0" minWidth="55.0" text="0" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="5" />
-                        <CheckBox fx:id="redLaserSoundCheckBox" mnemonicParsing="false" onAction="#redLaserSoundCheckBoxClicked" text="Red Laser Sound:" GridPane.rowIndex="2" />
-                        <CheckBox fx:id="greenLaserSoundCheckBox" mnemonicParsing="false" onAction="#greenLaserSoundCheckBoxClicked" text="Green Laser Sound:" GridPane.rowIndex="3" />
-                        <TextField fx:id="redLaserSoundTextField" disable="true" editable="false" GridPane.columnIndex="2" GridPane.rowIndex="2" />
-                        <TextField fx:id="greenLaserSoundTextField" disable="true" editable="false" GridPane.columnIndex="2" GridPane.rowIndex="3" />
-                        <Button fx:id="redLaserSoundButton" disable="true" mnemonicParsing="false" onAction="#redLaserSoundButtonClicked" text="..." GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="2" />
-                        <Button fx:id="greenLaserSoundButton" disable="true" mnemonicParsing="false" onAction="#greenLaserSoundButtonClicked" text="..." GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="3" />
+                        <Label text="Detection Sensitivity:" GridPane.rowIndex="1" />
+                        <Label fx:id="detectionSensitivityLabel" maxWidth="55.0" minWidth="55.0" text="5" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="1" />
+                        <Slider fx:id="detectionSensitivitySlider" blockIncrement="1.0" majorTickUnit="3.0" max="10.0" min="1.0" minorTickCount="2" showTickLabels="true" showTickMarks="true" value="5.0" GridPane.columnIndex="2" GridPane.rowIndex="1" />
+                        <Label text="Ignore Laser Color:" GridPane.rowIndex="2" />
+                        <CheckBox fx:id="virtualMagazineCheckBox" mnemonicParsing="false" onAction="#virtualMagazineCheckBoxClicked" text="Virtual Magazine:" GridPane.rowIndex="5" />
+                        <CheckBox fx:id="malfunctionsCheckBox" mnemonicParsing="false" onAction="#malfunctionsCheckBoxClicked" text="Inject Malfunctions (%):" GridPane.rowIndex="6" />
+                        <Slider fx:id="virtualMagazineSlider" blockIncrement="1.0" disable="true" majorTickUnit="5.0" max="45.0" min="1.0" minorTickCount="2" showTickLabels="true" showTickMarks="true" value="1.0" GridPane.columnIndex="2" GridPane.rowIndex="5" />
+                        <Slider fx:id="malfunctionsSlider" disable="true" max="99.9" min="0.1" showTickLabels="true" showTickMarks="true" GridPane.columnIndex="2" GridPane.rowIndex="6" />
+                        <ChoiceBox fx:id="ignoreLaserColorChoiceBox" prefWidth="300.0" GridPane.columnIndex="2" GridPane.columnSpan="2147483647" GridPane.hgrow="ALWAYS" GridPane.rowIndex="2" />
+                        <Label fx:id="virtualMagazineLabel" maxWidth="55.0" minWidth="55.0" text="0" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="5" />
+                        <Label fx:id="malfunctionsLabel" maxWidth="55.0" minWidth="55.0" text="0" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="6" />
+                        <CheckBox fx:id="redLaserSoundCheckBox" mnemonicParsing="false" onAction="#redLaserSoundCheckBoxClicked" text="Red Laser Sound:" GridPane.rowIndex="3" />
+                        <CheckBox fx:id="greenLaserSoundCheckBox" mnemonicParsing="false" onAction="#greenLaserSoundCheckBoxClicked" text="Green Laser Sound:" GridPane.rowIndex="4" />
+                        <TextField fx:id="redLaserSoundTextField" disable="true" editable="false" GridPane.columnIndex="2" GridPane.rowIndex="3" />
+                        <TextField fx:id="greenLaserSoundTextField" disable="true" editable="false" GridPane.columnIndex="2" GridPane.rowIndex="4" />
+                        <Button fx:id="redLaserSoundButton" disable="true" mnemonicParsing="false" onAction="#redLaserSoundButtonClicked" text="..." GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="3" />
+                        <Button fx:id="greenLaserSoundButton" disable="true" mnemonicParsing="false" onAction="#greenLaserSoundButtonClicked" text="..." GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="4" />
                      </children>
                      <padding>
                         <Insets left="30.0" right="30.0" top="30.0" bottom="30.0" />

--- a/src/main/resources/com/shootoff/gui/ShootOFF.fxml
+++ b/src/main/resources/com/shootoff/gui/ShootOFF.fxml
@@ -12,7 +12,6 @@
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.TableView?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
@@ -34,32 +33,24 @@
          <children>
             <SplitPane dividerPositions="0.24242424242424243, 0.8543771043771043" minHeight="480.0" minWidth="640.0">
               <items>
-                  <ScrollPane fitToHeight="true" fitToWidth="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="480.0" minWidth="295.0" prefViewportWidth="265.0">
+                  <ScrollPane fitToHeight="true" fitToWidth="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308">
                      <content>
-                        <TableView fx:id="shotTimerTable" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" />
+                        <TableView fx:id="shotTimerTable" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="100.0" />
                      </content>
                   </ScrollPane>
-                <AnchorPane minHeight="0.0" minWidth="0.0">
+                  <TabPane fx:id="cameraTabPane" minHeight="480.0" minWidth="640.0" prefHeight="480.0" prefWidth="640.0" tabClosingPolicy="UNAVAILABLE" />
+                  <VBox fx:id="buttonsContainer" alignment="TOP_CENTER" fillWidth="false" maxHeight="1.7976931348623157E308" maxWidth="200.0" prefWidth="200.0" spacing="30.0" SplitPane.resizableWithParent="false">
                      <children>
-                        <TabPane fx:id="cameraTabPane" minHeight="480.0" minWidth="640.0" prefHeight="480.0" prefWidth="751.0" tabClosingPolicy="UNAVAILABLE" />
+                        <Button mnemonicParsing="false" onAction="#resetClicked" prefHeight="30.0" prefWidth="150.0" text="Reset" GridPane.halignment="CENTER" GridPane.hgrow="NEVER" GridPane.valignment="CENTER" GridPane.vgrow="NEVER">
+                           <GridPane.margin>
+                              <Insets bottom="2.0" />
+                           </GridPane.margin>
+                        </Button>
                      </children>
-                  </AnchorPane>
-                  <AnchorPane maxWidth="-Infinity">
-                     <children>
-                        <VBox fx:id="buttonsContainer" alignment="TOP_CENTER" spacing="30.0">
-                           <children>
-                              <Button mnemonicParsing="false" onAction="#resetClicked" prefHeight="30.0" prefWidth="150.0" text="Reset" GridPane.halignment="CENTER" GridPane.hgrow="NEVER" GridPane.valignment="CENTER" GridPane.vgrow="NEVER">
-                                 <GridPane.margin>
-                                    <Insets bottom="2.0" />
-                                 </GridPane.margin>
-                              </Button>
-                           </children>
-                           <padding>
-                              <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                           </padding>
-                        </VBox>
-                     </children>
-                  </AnchorPane>
+                     <padding>
+                        <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                     </padding>
+                  </VBox>
               </items>
             </SplitPane>
             <ScrollPane fx:id="trainingExerciseScrollPane" hbarPolicy="NEVER" minHeight="150.0" HBox.hgrow="ALWAYS">

--- a/src/main/resources/com/shootoff/gui/ShootOFF.fxml
+++ b/src/main/resources/com/shootoff/gui/ShootOFF.fxml
@@ -16,7 +16,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox fx:id="shootOffContainer" prefHeight="576.0" prefWidth="959.0" xmlns="http://javafx.com/javafx/8.0.172-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.shootoff.gui.controller.ShootOFFController">
+<VBox fx:id="shootOffContainer" xmlns="http://javafx.com/javafx/8.0.172-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.shootoff.gui.controller.ShootOFFController">
    <children>
       <HBox fx:id="controlsContainer" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="60.0" prefHeight="60.0" prefWidth="1190.0" spacing="20.0">
          <children>
@@ -35,13 +35,13 @@
                <items>
                   <SplitPane dividerPositions="0.24242424242424243, 0.8543771043771043" maxHeight="1.7976931348623157E308" minHeight="480.0" minWidth="640.0">
                     <items>
-                        <ScrollPane fitToHeight="true" fitToWidth="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308">
+                        <ScrollPane fitToHeight="true" fitToWidth="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="0.0" minWidth="100.0">
                            <content>
-                              <TableView fx:id="shotTimerTable" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="100.0" />
+                              <TableView fx:id="shotTimerTable" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="0.0" minWidth="100.0" />
                            </content>
                         </ScrollPane>
-                        <TabPane fx:id="cameraTabPane" minHeight="480.0" minWidth="640.0" prefHeight="480.0" prefWidth="640.0" tabClosingPolicy="UNAVAILABLE" />
-                        <VBox fx:id="buttonsContainer" alignment="TOP_CENTER" fillWidth="false" maxHeight="1.7976931348623157E308" maxWidth="200.0" prefWidth="200.0" spacing="30.0" SplitPane.resizableWithParent="false">
+                        <TabPane fx:id="cameraTabPane" minHeight="240.0" minWidth="320.0" prefHeight="480.0" prefWidth="640.0" tabClosingPolicy="UNAVAILABLE" />
+                        <VBox fx:id="buttonsContainer" alignment="TOP_CENTER" fillWidth="false" maxHeight="1.7976931348623157E308" maxWidth="150.0" minHeight="240.0" minWidth="150.0" prefHeight="480.0" prefWidth="150.0" spacing="30.0" SplitPane.resizableWithParent="false">
                            <children>
                               <Button mnemonicParsing="false" onAction="#resetClicked" prefHeight="30.0" prefWidth="150.0" text="Reset" GridPane.halignment="CENTER" GridPane.hgrow="NEVER" GridPane.valignment="CENTER" GridPane.vgrow="NEVER">
                                  <GridPane.margin>
@@ -55,7 +55,7 @@
                         </VBox>
                     </items>
                   </SplitPane>
-                  <ScrollPane fx:id="trainingExerciseScrollPane" hbarPolicy="NEVER" minHeight="150.0">
+                  <ScrollPane fx:id="trainingExerciseScrollPane" hbarPolicy="NEVER" minHeight="150.0" minWidth="320.0">
                      <content>
                         <VBox fx:id="trainingExerciseContainer" />
                      </content>

--- a/src/main/resources/com/shootoff/gui/ShootOFF.fxml
+++ b/src/main/resources/com/shootoff/gui/ShootOFF.fxml
@@ -16,7 +16,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox fx:id="shootOffContainer" xmlns="http://javafx.com/javafx/8.0.172-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.shootoff.gui.controller.ShootOFFController">
+<VBox fx:id="shootOffContainer" prefHeight="576.0" prefWidth="959.0" xmlns="http://javafx.com/javafx/8.0.172-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.shootoff.gui.controller.ShootOFFController">
    <children>
       <HBox fx:id="controlsContainer" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="60.0" prefHeight="60.0" prefWidth="1190.0" spacing="20.0">
          <children>
@@ -29,35 +29,39 @@
             <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
          </padding>
       </HBox>
-      <VBox fx:id="bodyContainer">
+      <VBox fx:id="bodyContainer" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308">
          <children>
-            <SplitPane dividerPositions="0.24242424242424243, 0.8543771043771043" minHeight="480.0" minWidth="640.0">
-              <items>
-                  <ScrollPane fitToHeight="true" fitToWidth="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308">
+            <SplitPane dividerPositions="0.5" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" orientation="VERTICAL">
+               <items>
+                  <SplitPane dividerPositions="0.24242424242424243, 0.8543771043771043" maxHeight="1.7976931348623157E308" minHeight="480.0" minWidth="640.0">
+                    <items>
+                        <ScrollPane fitToHeight="true" fitToWidth="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308">
+                           <content>
+                              <TableView fx:id="shotTimerTable" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="100.0" />
+                           </content>
+                        </ScrollPane>
+                        <TabPane fx:id="cameraTabPane" minHeight="480.0" minWidth="640.0" prefHeight="480.0" prefWidth="640.0" tabClosingPolicy="UNAVAILABLE" />
+                        <VBox fx:id="buttonsContainer" alignment="TOP_CENTER" fillWidth="false" maxHeight="1.7976931348623157E308" maxWidth="200.0" prefWidth="200.0" spacing="30.0" SplitPane.resizableWithParent="false">
+                           <children>
+                              <Button mnemonicParsing="false" onAction="#resetClicked" prefHeight="30.0" prefWidth="150.0" text="Reset" GridPane.halignment="CENTER" GridPane.hgrow="NEVER" GridPane.valignment="CENTER" GridPane.vgrow="NEVER">
+                                 <GridPane.margin>
+                                    <Insets bottom="2.0" />
+                                 </GridPane.margin>
+                              </Button>
+                           </children>
+                           <padding>
+                              <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                           </padding>
+                        </VBox>
+                    </items>
+                  </SplitPane>
+                  <ScrollPane fx:id="trainingExerciseScrollPane" hbarPolicy="NEVER" minHeight="150.0">
                      <content>
-                        <TableView fx:id="shotTimerTable" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="100.0" />
+                        <VBox fx:id="trainingExerciseContainer" />
                      </content>
                   </ScrollPane>
-                  <TabPane fx:id="cameraTabPane" minHeight="480.0" minWidth="640.0" prefHeight="480.0" prefWidth="640.0" tabClosingPolicy="UNAVAILABLE" />
-                  <VBox fx:id="buttonsContainer" alignment="TOP_CENTER" fillWidth="false" maxHeight="1.7976931348623157E308" maxWidth="200.0" prefWidth="200.0" spacing="30.0" SplitPane.resizableWithParent="false">
-                     <children>
-                        <Button mnemonicParsing="false" onAction="#resetClicked" prefHeight="30.0" prefWidth="150.0" text="Reset" GridPane.halignment="CENTER" GridPane.hgrow="NEVER" GridPane.valignment="CENTER" GridPane.vgrow="NEVER">
-                           <GridPane.margin>
-                              <Insets bottom="2.0" />
-                           </GridPane.margin>
-                        </Button>
-                     </children>
-                     <padding>
-                        <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                     </padding>
-                  </VBox>
-              </items>
+               </items>
             </SplitPane>
-            <ScrollPane fx:id="trainingExerciseScrollPane" hbarPolicy="NEVER" minHeight="150.0" HBox.hgrow="ALWAYS">
-               <content>
-                  <VBox fx:id="trainingExerciseContainer" />
-               </content>
-            </ScrollPane>
          </children>
       </VBox>
    </children>

--- a/src/main/resources/com/shootoff/gui/ShootOFF.fxml
+++ b/src/main/resources/com/shootoff/gui/ShootOFF.fxml
@@ -6,19 +6,20 @@
  found in the LICENSE file.
 -->
 
-<?import javafx.scene.text.*?>
-<?import javafx.geometry.*?>
-<?import javafx.scene.*?>
-<?import javafx.scene.canvas.*?>
-<?import javafx.scene.input.*?>
-<?import javafx.scene.control.*?>
-<?import java.lang.*?>
-<?import javafx.scene.layout.*?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.SplitPane?>
+<?import javafx.scene.control.TabPane?>
+<?import javafx.scene.control.TableView?>
 <?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
 
-<VBox fx:id="shootOffContainer" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.shootoff.gui.controller.ShootOFFController">
+<VBox fx:id="shootOffContainer" xmlns="http://javafx.com/javafx/8.0.172-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.shootoff.gui.controller.ShootOFFController">
    <children>
-      <HBox fx:id="controlsContainer" alignment="TOP_CENTER" minHeight="160.0" prefWidth="200.0" spacing="175.0">
+      <HBox fx:id="controlsContainer" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="60.0" prefHeight="60.0" prefWidth="1190.0" spacing="20.0">
          <children>
             <Button mnemonicParsing="false" onMouseClicked="#fileButtonClicked" prefHeight="100.0" prefWidth="150.0" text="File" />
             <Button mnemonicParsing="false" onMouseClicked="#targetsButtonClicked" prefHeight="100.0" prefWidth="150.0" text="Targets" />
@@ -26,36 +27,41 @@
             <Button mnemonicParsing="false" onMouseClicked="#projectorButtonClicked" prefHeight="100.0" prefWidth="150.0" text="Projector" />
          </children>
          <padding>
-            <Insets bottom="30.0" left="30.0" right="30.0" top="30.0" />
+            <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
          </padding>
       </HBox>
       <VBox fx:id="bodyContainer">
          <children>
-            <HBox spacing="30.0" VBox.vgrow="ALWAYS">
-               <children>
-                  <ScrollPane fitToHeight="true" fitToWidth="true" prefViewportWidth="265.0" HBox.hgrow="ALWAYS">
+            <SplitPane dividerPositions="0.24242424242424243, 0.8543771043771043" minHeight="480.0" minWidth="640.0">
+              <items>
+                  <ScrollPane fitToHeight="true" fitToWidth="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="480.0" minWidth="295.0" prefViewportWidth="265.0">
                      <content>
-                        <TableView fx:id="shotTimerTable" minHeight="0.0" minWidth="0.0" />
+                        <TableView fx:id="shotTimerTable" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" />
                      </content>
                   </ScrollPane>
-                  <TabPane fx:id="cameraTabPane" minHeight="480.0" minWidth="640.0" prefHeight="480.0" prefWidth="640.0" tabClosingPolicy="UNAVAILABLE" HBox.hgrow="NEVER" />
-                  <VBox fx:id="buttonsContainer" alignment="CENTER" spacing="30.0">
+                <AnchorPane minHeight="0.0" minWidth="0.0">
                      <children>
-                        <Button mnemonicParsing="false" onAction="#resetClicked" prefHeight="100.0" prefWidth="150.0" text="Reset" GridPane.halignment="CENTER" GridPane.hgrow="NEVER" GridPane.valignment="CENTER" GridPane.vgrow="NEVER">
-                           <GridPane.margin>
-                              <Insets bottom="2.0" />
-                           </GridPane.margin>
-                        </Button>
+                        <TabPane fx:id="cameraTabPane" minHeight="480.0" minWidth="640.0" prefHeight="480.0" prefWidth="751.0" tabClosingPolicy="UNAVAILABLE" />
                      </children>
-                  </VBox>
-               </children>
-               <VBox.margin>
-                  <Insets />
-               </VBox.margin>
-               <padding>
-                  <Insets bottom="30.0" left="30.0" right="30.0" />
-               </padding>
-            </HBox>
+                  </AnchorPane>
+                  <AnchorPane maxWidth="-Infinity">
+                     <children>
+                        <VBox fx:id="buttonsContainer" alignment="TOP_CENTER" spacing="30.0">
+                           <children>
+                              <Button mnemonicParsing="false" onAction="#resetClicked" prefHeight="30.0" prefWidth="150.0" text="Reset" GridPane.halignment="CENTER" GridPane.hgrow="NEVER" GridPane.valignment="CENTER" GridPane.vgrow="NEVER">
+                                 <GridPane.margin>
+                                    <Insets bottom="2.0" />
+                                 </GridPane.margin>
+                              </Button>
+                           </children>
+                           <padding>
+                              <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                           </padding>
+                        </VBox>
+                     </children>
+                  </AnchorPane>
+              </items>
+            </SplitPane>
             <ScrollPane fx:id="trainingExerciseScrollPane" hbarPolicy="NEVER" minHeight="150.0" HBox.hgrow="ALWAYS">
                <content>
                   <VBox fx:id="trainingExerciseContainer" />

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,6 +7,7 @@
     </encoder>
   </appender>
 
+  <!--
   <appender name="Sentry" class="com.getsentry.raven.logback.SentryAppender">
     <dsn>http://e125530c2ca249bd956343ca2ad09dd4:c34458865bef486195a6b0341e95e3de@dev.shootoffapp.com:9000/1</dsn>
     <tags>shootoff-version:4.0</tags>
@@ -15,6 +16,7 @@
   <root level="warn">
     <appender-ref ref="Sentry"/>
   </root>
+  -->
 
   <root level="warn">
     <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
Title: Fix Linux support for modern distros (Pop!_OS 24.04, Ubuntu 22.04+)                                                                 
                                                                                                                                             
  Body:                                                                                                                                      
                                                                                                                                             
  Summary

  - Remove defunct shootoffapp.com version check (domain is permanently down)
  - Search multiple v4l1compat.so paths for Debian/Ubuntu multiarch layouts
  - Remove dead Bintray Maven repositories (shut down 2021)
  - Add shootoff.sh launcher script that auto-finds and preloads v4l1compat
  - Fix config parsing for camera names containing colons (split(":", 2))
  - Fix OpenCV 2.4 device index mismatch on systems with many /dev/video nodes
  - Add ffmpeg-based camera capture fallback when OpenCV can't handle a device (index > 7, modern kernel incompatibilities)
  - Add shutdown hook to clean up ffmpeg subprocess on exit
  - due to c02 actuators, ir lasers make a streak which previous code was not interpreting as a shot. added code to find first/brightest part of the IR streak and count that as a shot.

  Test plan

  - Tested on Pop!_OS 24.04 (kernel 6.x, Zulu JDK 8)
  - Verified camera capture works via ffmpeg fallback at 640x480
  - App launches, displays live camera feed, and exits cleanly